### PR TITLE
[codex] Add real-user benchmark harness

### DIFF
--- a/tests/real_user_benchmark/.gitignore
+++ b/tests/real_user_benchmark/.gitignore
@@ -1,0 +1,2 @@
+.results/
+node_modules/

--- a/tests/real_user_benchmark/README.md
+++ b/tests/real_user_benchmark/README.md
@@ -1,0 +1,249 @@
+# Istara Real User UX Research Benchmark
+
+This benchmark is a durable, repeatable long-form rehearsal of Istara as used by a realistic UX researcher. It is intentionally heavier than the normal simulation suite: it installs or targets sandboxed Istara services, generates a large synthetic research corpus, drives the actual UI where possible, exercises API-backed workflows, reviews tasks like a human researcher, records every action, and emits comparison-ready scorecards.
+
+Plan mode is credential-free. Probe and full comparison runs require donated compute and non-empty live chat by default, using the same configured `google/gemma-4-e4b` live-test profile as Istara's LLM eval contract. Offline harness debugging can opt out with explicit environment variables, but those runs should not be treated as product-quality comparisons.
+
+Every run loads the benchmark conductor system prompt from `tests/real_user_benchmark/system-prompt.md`, records its version and SHA-256 in `run-metadata.json`, copies the prompt into the run folder as `system-prompt.md`, and logs `system_prompt.loaded` in `action-log.jsonl`. This makes the simulation policy auditable across reruns.
+
+The benchmark is intentionally a longitudinal real-user layer, not a replacement for Istara's classical deterministic studies. It references `tests/simulation`, `tests/evals`, `tests/benchmarks`, and `scripts/security_benchmark.py` through `benchmark-registry.json`; it should not re-run or re-implement those suites inside the long-form user session.
+
+## Quick Start
+
+Run a static plan plus corpus generation without touching a live app:
+
+```bash
+npm --prefix tests/real_user_benchmark run plan
+```
+
+Run a short probe against an already running local Istara:
+
+```bash
+ISTARA_API_URL=http://localhost:8000 \
+ISTARA_FRONTEND_URL=http://localhost:3000 \
+ISTARA_E2E_ALLOW_LOCAL_TOKEN=1 \
+npm --prefix tests/real_user_benchmark run probe
+```
+
+This probe now expects a donated compute node and live chat output. For harness-only debugging against an app with no model connected, add `ISTARA_BENCHMARK_REQUIRE_COMPUTE_DONATION=0 ISTARA_BENCHMARK_REQUIRE_LIVE_CHAT=0`.
+
+Run the full benchmark with sandbox orchestration enabled:
+
+```bash
+ISTARA_BENCHMARK_ADMIN_USERNAME=admin \
+ISTARA_BENCHMARK_ADMIN_PASSWORD='IstaraBenchmarkAdmin123!' \
+npm --prefix tests/real_user_benchmark run full
+```
+
+The full run starts a fresh Team Mode server sandbox with an admin bootstrap user, drives the browser UI with those credentials, generates a user invite connection string, redeems that invite inside a separate disposable client container, grants the researcher access to the project, and runs a second Playwright journey as that researcher. When compute donation is required, the harness generates a per-run network token if one was not supplied, starts a separate relay client container using the same live LLM profile contract as `tests/llm_test_config.py`, waits for `/api/compute/stats` to show a relay node, and requires a relay-routed chat response before treating chat as useful evidence.
+
+Server and client sandboxes are separate. `--start-sandbox` starts Istara itself; donor/researcher containers are controlled by `ISTARA_BENCHMARK_START_CLIENT_SANDBOXES` and default on whenever donated compute or external connection strings are required. This means you can run the orchestrator outside Docker, generate connection strings in the real admin UI, pass those strings to the benchmark, and still have the benchmark spin up fresh disposable donor/researcher containers.
+
+The donated relay defaults to the shared live-test profile:
+
+- Base URL: `ISTARA_LIVE_LLM_BASE_URL`, then `ISTARA_PRIMARY_LLM_TEST_BASE_URL`, then `LMSTUDIO_HOST`, loaded from process env or gitignored `.env`, `.env.local`, `backend/.env`, and `backend/.env.local`.
+- Model: `google/gemma-4-e4b`, matching `PRIMARY_TEST_MODEL` in `tests/llm_test_config.py`.
+- Secret: `ISTARA_LIVE_LLM_API_KEY`, `ISTARA_LLM_TEST_API_KEY`, `ISTARA_PRIMARY_LLM_TEST_API_KEY`, `LMSTUDIO_API_KEY`, or the macOS Keychain service `istara-live-openai-compatible-tests`.
+- Container addressing: if the configured host is `localhost`, `127.0.0.1`, or `::1`, the relay container receives `host.docker.internal`; Linux runs also add a Docker host-gateway mapping. For LM Studio hosts ending in `/v1`, the benchmark strips that path for LM Studio native model/load endpoints while still using `/v1/chat/completions` for chat.
+
+Private endpoint values and tokens are never written to logs; run artifacts record only source names, booleans, redacted model/host metadata, and whether localhost translation or LM Studio path normalization occurred.
+
+## Multi-Donor Compute Mode
+
+Use multi-donor mode when you want one Istara orchestrator to receive compute from two or more simulated workstations. Each donor container runs Istara Relay and points at its own already provisioned LM Studio/OpenAI-compatible endpoint. The benchmark does not install LM Studio or download models inside the relay image; LM Studio is a desktop/runtime dependency that must already be running, or be replaced by a compatible test endpoint you provide.
+
+Default donor profile 1 is the configured live-test Gemma target:
+
+- Donor id: `donor-1-gemma4`
+- Model family: Gemma
+- Model contract: `google/gemma-4-e4b`
+
+Default donor profile 2 and above are Qwen placeholders:
+
+- Donor id: `donor-2-qwen35-4b`
+- Model family: Qwen
+- Model contract: `Qwen3.5-4B`
+- Provisioning: disabled until you supply an endpoint; the benchmark records a product/environment blocker instead of downloading or auto-loading a missing model.
+
+Example with two donated endpoints and an Istara server running outside Docker:
+
+```bash
+ISTARA_BENCHMARK_SKIP_SANDBOX=1 \
+ISTARA_BENCHMARK_START_CLIENT_SANDBOXES=1 \
+ISTARA_BENCHMARK_DONOR_COUNT=2 \
+ISTARA_BENCHMARK_DONOR_1_LLM_PROVIDER=lmstudio \
+ISTARA_BENCHMARK_DONOR_1_LLM_HOST=http://localhost:1234 \
+ISTARA_BENCHMARK_DONOR_1_LLM_MODEL=google/gemma-4-e4b \
+ISTARA_BENCHMARK_DONOR_1_LLM_API_KEY_ENV=LMSTUDIO_API_KEY \
+ISTARA_BENCHMARK_DONOR_2_LLM_PROVIDER=lmstudio \
+ISTARA_BENCHMARK_DONOR_2_LLM_HOST=http://localhost:2234 \
+ISTARA_BENCHMARK_DONOR_2_LLM_MODEL=Qwen3.5-4B \
+ISTARA_BENCHMARK_DONOR_2_LLM_API_KEY_ENV=QWEN_LMSTUDIO_API_KEY \
+ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRINGS="$GEMMA_COMPUTE_STRING,$QWEN_COMPUTE_STRING" \
+ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRINGS="$RESEARCHER_INVITE_STRING" \
+npm --prefix tests/real_user_benchmark run probe
+```
+
+If you want the benchmark to ask interactively, run from a real terminal:
+
+```bash
+ISTARA_BENCHMARK_SKIP_SANDBOX=1 \
+ISTARA_BENCHMARK_EXTERNAL_CONNECTION_STRINGS=1 \
+ISTARA_BENCHMARK_INTERACTIVE_CONNECTION_STRINGS=1 \
+npm --prefix tests/real_user_benchmark run probe
+```
+
+The prompt asks how many compute donor containers and researcher invite containers to start, then accepts per-donor compute donation strings and researcher invite strings. Empty answers mean “generate through the Istara API if the admin session can do so.”
+
+If an externally generated compute donation string contains `localhost`, the relay container rewrites only its local copy of the relay payload to use `host.docker.internal` so the donor can reach the host orchestrator. This is safe for relay bootstrap because the standalone relay does not verify the connection-string HMAC; it only needs the embedded network token and WebSocket URL. User invite strings are not rewritten, because Istara validates their HMAC and database hash during validation/redemption.
+
+For noninteractive CI or repeated local runs, use a gitignored JSON file:
+
+```json
+{
+  "compute_donations": ["rcl_...", "rcl_..."],
+  "user_invites": ["rcl_..."]
+}
+```
+
+Then run:
+
+```bash
+ISTARA_BENCHMARK_CONNECTION_STRINGS_FILE=.istara-benchmark-connections.local.json \
+ISTARA_BENCHMARK_DONOR_COUNT=2 \
+npm --prefix tests/real_user_benchmark run probe
+```
+
+When two required donors are configured, the benchmark waits for `/api/compute/stats` to expose two relay/browser nodes. The run records `compute-donation-results.json`, per-donor `relay-llm-preflight-<donor>.json`, connection-string materialization evidence, route evidence, and whether multi-donor compute was actually verified. If only one donor is reachable, the run is not silently accepted as a multi-donor success.
+
+If Docker or the app blocks completion, the run is still useful: the blocker, logs, screenshots, and partial results are preserved. The harness treats first failures as prompts for architecture-aware diagnosis: it checks whether the benchmark misunderstood Istara state, auth, onboarding, or render timing before logging a product finding.
+
+On macOS without Docker Desktop, install and start Colima once:
+
+```bash
+brew install colima docker-compose
+colima start --cpu 4 --memory 6 --root-disk 10 --disk 10 --runtime docker
+docker info
+```
+
+The benchmark will also try to auto-start Colima when `--start-sandbox` is used and `colima` is installed. Auto-start defaults to `--root-disk 10 --disk 10`, which produces a 20GB apparent sparse ceiling and should stay under the 10GB actual-data budget for normal benchmark runs. Disable auto-start with `ISTARA_BENCHMARK_AUTOSTART_COLIMA=0`.
+
+Existing Colima disks cannot be shrunk in place. If `du -sh -A ~/.colima` still reports a larger apparent ceiling from an older profile, recreate the profile after preserving anything important in Docker:
+
+```bash
+colima stop
+colima delete -f
+colima start --cpu 4 --memory 6 --root-disk 10 --disk 10 --runtime docker
+```
+
+## Modes
+
+- `plan-only`: creates the run folder, corpus, playbook snapshot, feature matrix, and scorecard scaffold.
+- `probe`: targets existing services and runs a bounded subset of onboarding, integration, chat, upload, and review flows.
+- `full`: targets or starts sandboxed services and aims for 100 chat turns plus 50 human-approved tasks.
+
+## Important Environment Variables
+
+- `ISTARA_API_URL`: backend URL, default `http://localhost:8000`.
+- `ISTARA_FRONTEND_URL`: frontend URL, default `http://localhost:3000`.
+- `ISTARA_E2E_ALLOW_LOCAL_TOKEN=1`: allows the benchmark to mint a local signed token from backend code for test-only auth.
+- `ISTARA_BENCHMARK_LLM_PROFILE`: descriptive name for a non-donated fallback profile used during full runs.
+- `ISTARA_BENCHMARK_LLM_MODEL`: fallback Ollama model for non-donated sandbox paths. Donated compute uses the shared live LLM contract above unless `ISTARA_BENCHMARK_RELAY_LLM_MODEL` is explicitly set.
+- `ISTARA_BENCHMARK_RESULTS_DIR`: override result output root.
+- `ISTARA_BENCHMARK_SKIP_SANDBOX=1`: target existing app services even in full mode.
+- `ISTARA_BENCHMARK_START_CLIENT_SANDBOXES`: controls disposable researcher/relay containers separately from the server sandbox. Defaults to on for donated-compute and external-connection runs.
+- `ISTARA_BENCHMARK_EXTERNAL_CONNECTION_STRINGS=1`: consume connection strings supplied by env, JSON file, donor profile, or interactive prompt before generating new ones through the API.
+- `ISTARA_BENCHMARK_INTERACTIVE_CONNECTION_STRINGS=1`: ask how many donor/researcher containers to start and prompt for strings in a TTY.
+- `ISTARA_BENCHMARK_DONOR_COUNT`: number of required compute donor containers. Default `1`.
+- `ISTARA_BENCHMARK_RESEARCHER_COUNT`: number of researcher invite/client containers. Default `1`.
+- `ISTARA_BENCHMARK_CONNECTION_STRINGS_FILE`: gitignored JSON file with `compute_donations` and `user_invites` arrays.
+- `ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRINGS`: comma, newline, pipe, or JSON-array list of compute donation strings.
+- `ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRINGS`: comma, newline, pipe, or JSON-array list of researcher invite strings.
+- `ISTARA_BENCHMARK_FRESH_SANDBOX=0`: reuse existing benchmark containers and volumes. The default is `1`, which recreates the server/client sandbox state for reproducibility.
+- `ISTARA_BENCHMARK_TEAM_MODE`: defaults to `true` for browser-testable sandbox auth.
+- `ISTARA_BENCHMARK_ADMIN_USERNAME` and `ISTARA_BENCHMARK_ADMIN_PASSWORD`: bootstrap credentials for the sandbox admin account.
+- `ISTARA_BENCHMARK_REQUIRE_COMPUTE_DONATION`: defaults to `1` for every non-plan run. The harness uses a per-run network token when no `NETWORK_ACCESS_TOKEN` or `ISTARA_BENCHMARK_NETWORK_ACCESS_TOKEN` is present.
+- `ISTARA_BENCHMARK_REQUIRE_LIVE_CHAT`: defaults to `1` for full runs and whenever compute donation is required. Empty assistant text or SSE chat errors fail the benchmark instead of counting the turn.
+- `ISTARA_BENCHMARK_FORCE_DONATED_CHAT=1`: defaults to `1` when compute donation is required. It intentionally makes the server's direct LM Studio and Ollama routes unreachable so chat must fall through to the donated relay path.
+- `ISTARA_BENCHMARK_LMSTUDIO_AUTO_LOAD_ENABLED`: defaults to `true` when compute donation is required so the server can ask the relay to load the configured LM Studio model once before declaring the donated node unusable.
+- `ISTARA_BENCHMARK_LMSTUDIO_AUTO_CONTEXT_RELOAD`: defaults to `true` when compute donation is required so real chat prompts can ask the donated LM Studio relay to reload the configured model with a larger context window before the routing layer opens the streaming circuit breaker.
+- `ISTARA_BENCHMARK_STRICT_AUTO_ROUTING`: defaults to `true` when compute donation is required so the benchmark stays pinned to the configured LM Studio model instead of recovering by loading a different advertised model.
+- `ISTARA_BENCHMARK_PRUNE_DANGLING_IMAGES`: defaults to `true`; after Docker rebuilds the harness prunes dangling image layers so repeated runs do not inflate Colima/Docker disk usage. Active containers, tagged images, and volumes are not removed by this step.
+- `ISTARA_BENCHMARK_INSTALL_WHISPER`: defaults to `false` for benchmark Docker builds. Voice transcription remains exercised through UI/API graceful-degradation paths, while avoiding the Torch/Whisper dependency stack in the reusable benchmark image.
+- `ISTARA_BENCHMARK_RELAY_LLM_PROVIDER`, `ISTARA_BENCHMARK_RELAY_LLM_HOST`, `ISTARA_BENCHMARK_RELAY_LLM_MODEL`, `ISTARA_BENCHMARK_RELAY_LLM_API_KEY`: optional overrides for the client-side donated target. If omitted, the benchmark uses `tests/llm_test_config.py` live-profile rules without logging secret values.
+- `ISTARA_BENCHMARK_DONOR_<N>_LLM_PROVIDER`, `ISTARA_BENCHMARK_DONOR_<N>_LLM_HOST`, `ISTARA_BENCHMARK_DONOR_<N>_LLM_MODEL`, `ISTARA_BENCHMARK_DONOR_<N>_LLM_API_KEY`, `ISTARA_BENCHMARK_DONOR_<N>_LLM_API_KEY_ENV`, `ISTARA_BENCHMARK_DONOR_<N>_CONNECTION_STRING`: per-donor overrides for multi-donor runs. Prefer `*_API_KEY_ENV` so secrets stay outside process logs.
+- `ISTARA_BENCHMARK_DONOR_PROFILES_JSON` or `ISTARA_BENCHMARK_DONOR_PROFILES_FILE`: advanced JSON donor profile configuration. Profiles can include `id`, `provider`, `llm_host`, `model`, `api_key_env`, and `connection_string`.
+- `ISTARA_BENCHMARK_QWEN_LLM_HOST`, `ISTARA_BENCHMARK_QWEN_LLM_MODEL`, `ISTARA_BENCHMARK_QWEN_LLM_API_KEY_ENV`: convenience configuration for the future Qwen donor profile.
+- `ISTARA_BENCHMARK_NETWORK_ACCESS_TOKEN`: optional fixed network token for relay testing. Omit it for a fresh per-run token.
+- `ISTARA_BENCHMARK_AUTOSTART_COLIMA=0`: prevent automatic Colima startup.
+- `ISTARA_BENCHMARK_COLIMA_CPU`, `ISTARA_BENCHMARK_COLIMA_MEMORY`, `ISTARA_BENCHMARK_COLIMA_ROOT_DISK`, `ISTARA_BENCHMARK_COLIMA_DISK`: resource settings for automatic Colima startup. Defaults are CPU `4`, memory `6`, root disk `10` GB, and data disk `10` GB.
+- `ISTARA_BENCHMARK_COLIMA_MAX_ACTUAL_GB`, `ISTARA_BENCHMARK_COLIMA_MAX_APPARENT_GB`, `ISTARA_BENCHMARK_COLIMA_STORAGE_TOLERANCE_GB`, `ISTARA_BENCHMARK_COLIMA_STORAGE_POLICY`: storage budgets recorded in every run. Defaults are 10GB actual, 20GB apparent, 0.25GB tolerance for filesystem metadata, and `warn`. Use `ISTARA_BENCHMARK_COLIMA_STORAGE_POLICY=fail` for CI-style hard enforcement.
+- `ISTARA_BENCHMARK_KEEP_CLIENT_CONTAINERS=1`: keep temporary relay/client containers after a run for interactive debugging. By default their logs are captured and the containers are removed.
+
+No script in this benchmark deletes, prunes, moves, or cleans `LLMs/` or `Model_Finetuning/`.
+
+## Outputs
+
+Every run creates a timestamped folder under `tests/real_user_benchmark/.results/runs/` with:
+
+- `action-log.jsonl`: every benchmark action and result.
+- `conversation-turns.jsonl`: chat prompts, responses, timings, and quality notes.
+- `task-review-log.jsonl`: task creation, review, revision, and approval records.
+- `integration-attempts.jsonl`: third-party integration attempts and classifications.
+- `corpus/`: generated UX research documents.
+- `corpus-manifest.json`: document inventory and intended use.
+- `screenshots/` and `traces/`: Playwright evidence.
+- `report.md`: human-readable run narrative.
+- `scorecard.json`: comparison-ready numeric scores.
+- `history-record.json`: compact metrics for regression tracking.
+- `benchmark-registry-snapshot.json`: the suite/standards alignment active for that run.
+- `system-prompt.md`: the exact benchmark conductor prompt active for that run.
+- `relay-llm-preflight.json` and `relay-llm-preflight-<donor>.json`: redacted evidence that each donor container could reach its configured LM Studio/OpenAI-compatible target and complete a tiny chat request.
+- `compute-donation-results.json`: relay registration, relay-routed chat verification method, forced-topology evidence when logs are quiet, and response evidence.
+- `storage/colima-*.json`: actual and apparent Colima disk snapshots, storage budget status, and remediation guidance.
+
+The backend sandbox mounts the benchmark result root at `/benchmark-results` so linked-folder flows can point at the generated corpus from inside the container. This is deliberately separate from API uploads: the benchmark tests both folder context and upload ingestion.
+
+The result root also keeps comparison indexes:
+
+- `.results/history.jsonl`: one compact record per completed benchmark run.
+- `.results/latest-run.json`: pointer to the latest completed run, report, scorecard, and summary.
+
+## Credential-Free Integration Policy
+
+The benchmark first discovers developer-friendly paths in code and API behavior:
+
+- mock endpoints
+- sandbox flags
+- fake provider support
+- local API host overrides
+- webhook simulators
+- fixture sync paths
+- graceful setup and validation errors
+
+If no such path exists, that is treated as a product finding, not a benchmark failure.
+
+Optional live credentials may be supplied by the user in their environment, but the default run never requires Google Stitch, Figma, Google Forms, SurveyMonkey, Typeform, Telegram, Slack, WhatsApp, Google Chat, or MCP credentials.
+
+## Agentic And Industry Eval Alignment
+
+The long-form benchmark does not replace the deterministic evaluation suites. It reads `benchmark-registry.json` on every run, snapshots it into the result folder, and records the companion suite paths in `history-record.json`.
+
+Default researcher turns now probe:
+
+- donated compute and live chat on `google/gemma-4-e4b`
+- tool calling and skill calling observability
+- RAG/source grounding, context management, and contradiction handling
+- ReasoningBank, memento, and project-memory behavior
+- Hyperagent or governed-improvement safe paths
+- ensemble/MoA health surfaces and compute readiness
+
+The classical scoring baselines remain in `testing/TESTING_STRATEGY.md`, `testing/AI_EVALS_STRATEGY.md`, `tests/agentic_eval_contract.json`, `tests/evals`, and `tests/benchmarks`.
+
+## Donor Profile Policy
+
+The default comparison profile still uses one bounded donated LM Studio target: `google/gemma-4-e4b`. Multi-donor runs are now supported, but every additional donor must point at an already provisioned endpoint. The Qwen3.5-4B profile is available as a required donor when `ISTARA_BENCHMARK_DONOR_COUNT=2`, yet it remains endpoint-gated: without a configured host/API key/model serving process, the benchmark logs a blocker and does not fake ensemble health.
+
+## UI Harness Rules
+
+Playwright waits for the actual rendered app state before navigation. It classifies login, onboarding, chat, shell, no-project, server-unreachable, and blank states; after real UI authentication it selects the generated project and marks the benchmark tour complete so the first-run tour does not force navigation back to Settings during menu coverage. Sidebar clicks are attempted through accessible tab/button locators first, with any fallback clearly logged in `action-log.jsonl`.

--- a/tests/real_user_benchmark/benchmark-plan.md
+++ b/tests/real_user_benchmark/benchmark-plan.md
@@ -1,0 +1,112 @@
+# Benchmark Plan
+
+## Researcher Persona
+
+Name: Maya Rodrigues
+
+Role: senior UX researcher at Northstar Health, working on a patient-care coordination product used by clinic staff, patients, and family caregivers.
+
+Behavioral model:
+
+- Maya asks open-ended questions, then narrows into evidence checks.
+- She uploads messy historical research because real teams inherit imperfect archives.
+- She corrects vague summaries and asks Istara to cite sources.
+- She creates work, waits for Review, reads the output, approves good work, and sends weak work back with concrete revision instructions.
+- She tests third-party setup flows even when she knows credentials are unavailable.
+
+## Project Narrative
+
+Project: CareNav Renewal
+
+Problem: care coordinators lose time reconciling patient tasks across portals, SMS threads, paper notes, and phone calls. Patients and caregivers miss preparation steps before appointments, while staff cannot tell which reminders worked.
+
+Benchmark goals:
+
+- Validate whether Istara can ground recommendations in a large messy corpus.
+- Validate whether real donated compute can serve live `google/gemma-4-e4b` chat before research-quality scoring begins.
+- Measure whether reports and atomic findings make sense across mixed methods.
+- Probe Istara's agentic stack through realistic researcher requests: tool calls, skill calls, RAG, context management, memento/project memory, ReasoningBank, Hyperagent/governed improvement, and ensemble/MoA health.
+- Exercise the human review loop instead of assuming agent tasks are done.
+- Test whether integrations fail helpfully without credentials.
+- Produce reusable evidence that can be compared across product builds.
+- Complement, not duplicate, the deterministic coverage already tracked in `tests/simulation`, `tests/evals`, `tests/benchmarks`, and `scripts/security_benchmark.py`.
+
+## Operating Discipline
+
+The benchmark is not a happy-path script. When an action fails, the harness first checks whether the failure came from benchmark misunderstanding: wrong auth mode, stale first-run tour state, frontend runtime config, missing render wait, inaccessible container path, or an unsupported integration credential profile. Only after that architecture check does it log a product issue.
+
+For UI actions, Playwright waits until Istara has rendered a usable state before navigation or chat input. For task review, the benchmark reads the task output, records a human-quality judgment, sends weak work back with specific revision instructions, then approves only after the simulated researcher decides the output is good enough.
+
+For compute, the benchmark treats the donated relay as part of the product under test. Non-plan runs require the configured live model profile by default, verify the relay node through `/api/compute/stats`, and require non-empty chat output before later research tasks can count as successful.
+
+## Corpus
+
+The generator creates:
+
+- interview transcripts
+- usability test notes
+- survey CSVs
+- diary studies
+- field notes
+- analytics exports
+- support tickets
+- design critique notes
+- competitor reviews
+- research readouts and presentation files
+- malformed and edge-case files
+- multilingual Portuguese and Spanish examples
+- URL and web-fetch prompts
+
+The generated corpus intentionally contains overlap, contradictions, missing metadata, and repeated pain points so Istara must synthesize rather than simply list.
+
+## Feature Coverage Matrix
+
+| Feature | Required Evidence |
+| --- | --- |
+| Sandboxed server install | container/log evidence or blocker |
+| Connection string | generated user invite and compute donation string where available |
+| Sandboxed client install | relay/client connection attempt or blocker |
+| Onboarding UI | Playwright screenshots/traces |
+| Project context | project create/update payload and UI evidence |
+| Linked folders | backend-visible `/benchmark-results/.../corpus` folder path plus API result |
+| Uploads | manifest plus upload responses |
+| Chat | 100 JSONL turns in full mode |
+| Donated compute | relay/client registration, forced topology or route-log evidence, and live Gemma response |
+| Tool/skill calls | natural researcher prompts that require tool or skill attempts, plus trace/observability findings |
+| RAG/context | retrieved-source usefulness, citations, contradictions, and context-window stress prompts |
+| Memento/ReasoningBank | memory/reasoning-bank request evidence and contamination/grounding review |
+| Hyperagent/governed improvement | bounded safe-path attempt and human review of proposed improvement |
+| Ensemble/MoA health | compute-health and ensemble-readiness evidence; future Qwen donor remains disabled until provisioned |
+| Task review | 50 approved tasks in full mode, with revision examples |
+| Loops | overview/config/schedule/custom loop attempts |
+| Autoresearch | status/config/toggle/error-path evidence |
+| Surveys | Google Forms, SurveyMonkey, Typeform developer/demo path or error path |
+| Telegram/AURA | fake Telegram setup, deployment creation, activation, response simulation attempt |
+| URL/web fetching | chat/task URL prompts and response quality notes |
+| Interfaces | mock Stitch/Figma generation/import, design chat, handoff where possible |
+| MCP | server/client status, policy, fake client discovery error path |
+| Reports/findings | report and atomic research endpoints or chat-generated artifacts |
+
+## Scoring Rubric
+
+The final score is out of 100:
+
+- install and sandbox behavior: 10
+- onboarding and project setup: 8
+- corpus ingestion and uploads: 10
+- chat quality and naturalness: 10
+- grounding and evidence handling: 10
+- task execution and human review workflow: 12
+- reports, findings, and atomic research: 10
+- integrations and graceful degradation: 10
+- Autoresearch, loops, and scheduled work: 6
+- URL fetching and web context: 4
+- interface generation and design handoff: 4
+- stability and performance: 4
+- overall researcher usefulness: 2
+
+The scorecard includes explanations and product improvement notes, not just numbers.
+
+Storage is part of run hygiene. Colima autostart uses a 10GB root disk and 10GB data disk by default, snapshots actual/apparent usage, and records a product/process finding when the benchmark environment exceeds the 10GB actual or 20GB apparent budgets.
+
+Recurring product findings should be tracked over time rather than discarded. Current expected high-signal findings include lack of a credential-free AURA participant conversation simulator and missing support for realistic archive types such as `.pptx` research readouts and `.jsonl` support-ticket exports.

--- a/tests/real_user_benchmark/benchmark-registry.json
+++ b/tests/real_user_benchmark/benchmark-registry.json
@@ -1,0 +1,127 @@
+{
+  "version": "2026-05-09.3",
+  "benchmark_id": "istara-real-user-ux-research-longform",
+  "purpose": "Longitudinal, human-in-the-loop UX research benchmark that complements deterministic Istara scenario, eval, security, and long-horizon benchmark suites.",
+  "non_duplication_policy": "Do not re-run or re-implement classical deterministic studies from tests/simulation, tests/evals, tests/benchmarks, or scripts/security_benchmark.py inside this benchmark. Treat those suites as baseline evidence. This benchmark should test realistic cross-feature user behavior, longitudinal usefulness, integration ergonomics, compute donation, and human review quality.",
+  "default_run_contract": {
+    "non_plan_runs_require_compute_donation": true,
+    "non_plan_runs_require_non_empty_live_chat": true,
+    "force_donated_chat_when_compute_required": true,
+    "storage_guardrail": "Colima autostart uses --root-disk 10 --disk 10 and records actual/apparent storage snapshots with 10GB actual and 20GB apparent budgets.",
+    "client_sandbox_policy": "Server sandboxing and client/donor sandboxing are independent. External Istara servers can receive donated compute from disposable benchmark containers.",
+    "multi_donor_policy": "Default comparison uses one Gemma donor. Multi-donor runs require per-donor pre-provisioned OpenAI-compatible/LM Studio endpoints and connection strings; missing Qwen endpoints are blockers, not downloads.",
+    "opt_out": "Set ISTARA_BENCHMARK_REQUIRE_COMPUTE_DONATION=0 and ISTARA_BENCHMARK_REQUIRE_LIVE_CHAT=0 only for offline harness debugging, not comparison runs."
+  },
+  "live_model_profile": {
+    "source": "tests/llm_test_config.py",
+    "model": "google/gemma-4-e4b",
+    "provider_contract": "one configured OpenAI-compatible/LM Studio target loaded from gitignored env or Keychain",
+    "multiple_heavy_models_allowed": false,
+    "multi_donor_exception": "Only explicit multi-donor benchmark runs may use additional already-provisioned per-donor endpoints such as Qwen3.5-4B. The benchmark must not download missing models."
+  },
+  "companion_suites": [
+    {
+      "path": "tests/simulation",
+      "role": "Deterministic feature and menu scenario coverage.",
+      "relationship": "Reference for coverage mapping; do not duplicate scenario assertions."
+    },
+    {
+      "path": "tests/evals",
+      "role": "Tracked AI eval definitions and live-LLM quality probes.",
+      "relationship": "Reference for model-serving and quality baselines; this benchmark adds realistic product workflow evidence."
+    },
+    {
+      "path": "tests/benchmarks",
+      "role": "Classical long-horizon and orchestration benchmarks.",
+      "relationship": "Reference for agent orchestration baseline; this benchmark adds UI, onboarding, integrations, and human task review."
+    },
+    {
+      "path": "scripts/security_benchmark.py",
+      "role": "Tracked security control benchmark.",
+      "relationship": "Run as a separate gate for auth, connection-string, compute, MCP, webhook, and LLM-provider changes."
+    }
+  ],
+  "agentic_eval_focus": [
+    {
+      "area": "live chat and donated compute routing",
+      "baseline": "testing/TESTING_STRATEGY.md live LLM contract and tests/integration/test_llm_orchestration_real.py",
+      "benchmark_role": "Prove that realistic chat turns return non-empty output through the donated compute path before scoring researcher usefulness."
+    },
+    {
+      "area": "tool calling and ReAct skill use",
+      "baseline": "tests/agentic_eval_contract.json and testing/AI_EVALS_STRATEGY.md BFCL/ReAct sections",
+      "benchmark_role": "Ask natural researcher requests that require tool/skill attempts and record whether Istara exposes useful call evidence."
+    },
+    {
+      "area": "RAG and context management",
+      "baseline": "tests/evals plus Ragas/TruLens-inspired metrics in testing/AI_EVALS_STRATEGY.md",
+      "benchmark_role": "Check retrieved-source usefulness, citations, contradictions, uploaded-corpus grounding, and context-window stress behavior."
+    },
+    {
+      "area": "ReasoningBank and memento",
+      "baseline": "tests/agentic_eval_contract.json memory and ReasoningBank suites",
+      "benchmark_role": "Ask whether stored project memory improves current synthesis without overriding fresh evidence."
+    },
+    {
+      "area": "Hyperagent and governed improvement",
+      "baseline": "tests/agentic_eval_contract.json hyperagent/governed-improvement suites",
+      "benchmark_role": "Use the safest product path to propose bounded benchmark/process improvements and review their quality."
+    },
+    {
+      "area": "ensemble and MoA health",
+      "baseline": "tests/agentic_eval_contract.json ensemble orchestration suite",
+      "benchmark_role": "Record compute-health and ensemble/MoA readiness evidence; multi-donor runs wait for the requested relay-node count and preserve route evidence before scoring ensemble readiness."
+    }
+  ],
+  "future_multi_donor_profiles": [
+    {
+      "id": "donor-admin-gemma4",
+      "persona": "admin/server-side benchmark researcher workstation",
+      "model": "google/gemma-4-e4b",
+      "provider": "LM Studio/OpenAI-compatible",
+      "enabled_by_default": true,
+      "model_download_allowed": false,
+      "runtime_status": "default-comparison-donor",
+      "notes": "Uses the existing configured live test target. Sensitive host/token values stay outside committed files."
+    },
+    {
+      "id": "donor-researcher-qwen35-4b",
+      "persona": "future separate researcher workstation",
+      "model": "Qwen3.5-4B",
+      "provider": "LM Studio/OpenAI-compatible",
+      "enabled_by_default": false,
+      "model_download_allowed": false,
+      "runtime_status": "endpoint-gated-donor",
+      "notes": "Activated by ISTARA_BENCHMARK_DONOR_COUNT=2 plus a provisioned endpoint such as ISTARA_BENCHMARK_DONOR_2_LLM_HOST or ISTARA_BENCHMARK_QWEN_LLM_HOST. Do not download or autoload this model until explicitly provisioned by the user."
+    }
+  ],
+  "industry_alignment": [
+    {
+      "reference": "ISO/IEC/IEEE 29119-style test process",
+      "applied_as": "Explicit test objective, reusable test design, execution logs, incident evidence, and repeatable reporting."
+    },
+    {
+      "reference": "ISO/IEC 25010 quality model",
+      "applied_as": "Score dimensions cover functional suitability, usability, reliability, performance, security-sensitive integration behavior, and maintainability of the benchmark evidence."
+    },
+    {
+      "reference": "ISO 9241-210 human-centred design",
+      "applied_as": "Scenario uses a realistic UX researcher persona, context of use, evidence review, and human decision points."
+    },
+    {
+      "reference": "ISTQB exploratory and session-based testing practice",
+      "applied_as": "Long-form chartered session with natural steering, timestamped notes, observed failures, and product-risk classification."
+    },
+    {
+      "reference": "AI evaluation and red-team evidence practice",
+      "applied_as": "Preserves prompts, responses, model-routing evidence, tool behavior, integration blockers, and comparison-ready history without storing private endpoints or tokens."
+    }
+  ],
+  "history_outputs": [
+    "tests/real_user_benchmark/.results/runs/<run_id>/history-record.json",
+    "tests/real_user_benchmark/.results/runs/<run_id>/benchmark-registry-snapshot.json",
+    "tests/real_user_benchmark/.results/runs/<run_id>/storage/colima-*.json",
+    "tests/real_user_benchmark/.results/history.jsonl",
+    "tests/real_user_benchmark/.results/latest-run.json"
+  ]
+}

--- a/tests/real_user_benchmark/compass-spec-41-clarifications.json
+++ b/tests/real_user_benchmark/compass-spec-41-clarifications.json
@@ -1,0 +1,3 @@
+{
+  "scope-boundary": "Change the reusable benchmark implementation, Docker benchmark setup, Playwright UI harness, benchmark docs, and benchmark evidence logging only. Preserve Istara product behavior unless a verified blocker requires a scoped fix. Every failed benchmark action must first diagnose Istara auth, onboarding, project selection, UI readiness, and relevant architecture; correct benchmark misunderstandings; retry; and only then log a product issue with evidence. The benchmark must prove app-shell readiness before UI navigation and must complete the sandboxed server/client install, connection-string flow, chat, task review, integrations, AURA/Telegram, URL fetching, reports, interfaces, and scoring requirements or document a verified blocker."
+}

--- a/tests/real_user_benchmark/docker-compose.benchmark.yml
+++ b/tests/real_user_benchmark/docker-compose.benchmark.yml
@@ -1,0 +1,77 @@
+name: istara-real-user-benchmark
+
+services:
+  ollama:
+    container_name: istara-benchmark-ollama
+    volumes:
+      - istara_benchmark_ollama:/root/.ollama
+
+  backend:
+    container_name: istara-benchmark-backend
+    build:
+      args:
+        - INSTALL_WHISPER=${ISTARA_BENCHMARK_INSTALL_WHISPER:-false}
+    ports:
+      - "${ISTARA_BENCHMARK_API_PORT:-18000}:8000"
+    volumes:
+      - istara_benchmark_backend_data:/app/data
+      - istara_benchmark_watch:/app/watch:ro
+      - ./tests/real_user_benchmark/.results:/benchmark-results:ro
+    environment:
+      - DATABASE_URL=sqlite+aiosqlite:///./data/istara.db
+      - LANCE_DB_PATH=./data/lance_db
+      - UPLOAD_DIR=./data/uploads
+      - PROJECTS_DIR=./data/projects
+      - LLM_PROVIDER=${ISTARA_BENCHMARK_SERVER_LLM_PROVIDER:-ollama}
+      - LMSTUDIO_AUTO_LOAD_ENABLED=${ISTARA_BENCHMARK_LMSTUDIO_AUTO_LOAD_ENABLED:-false}
+      - LMSTUDIO_AUTO_CONTEXT_RELOAD=${ISTARA_BENCHMARK_LMSTUDIO_AUTO_CONTEXT_RELOAD:-false}
+      - STRICT_AUTO_ROUTING=${ISTARA_BENCHMARK_STRICT_AUTO_ROUTING:-false}
+      - LMSTUDIO_MAX_LOAD_ATTEMPTS_PER_REQUEST=${ISTARA_BENCHMARK_LMSTUDIO_MAX_LOAD_ATTEMPTS_PER_REQUEST:-1}
+      - LLM_CAPABILITY_ACTIVE_PROBE_ENABLED=false
+      - LMSTUDIO_HOST=${ISTARA_BENCHMARK_SERVER_LMSTUDIO_HOST:-http://host.docker.internal:1234}
+      - LMSTUDIO_MODEL=${ISTARA_BENCHMARK_SERVER_LMSTUDIO_MODEL:-default}
+      - LMSTUDIO_API_KEY=${ISTARA_BENCHMARK_SERVER_LMSTUDIO_API_KEY:-}
+      - TEAM_MODE=${ISTARA_BENCHMARK_TEAM_MODE:-true}
+      - ADMIN_USERNAME=${ISTARA_BENCHMARK_ADMIN_USERNAME:-admin}
+      - ADMIN_PASSWORD=${ISTARA_BENCHMARK_ADMIN_PASSWORD:-IstaraBenchmarkAdmin123!}
+      - RATE_LIMIT_ENABLED=false
+      - JWT_SECRET=istara-real-user-benchmark-jwt-secret
+      - NETWORK_ACCESS_TOKEN=${NETWORK_ACCESS_TOKEN:-}
+      - CORS_ORIGINS=http://localhost:${ISTARA_BENCHMARK_FRONTEND_PORT:-13000},http://127.0.0.1:${ISTARA_BENCHMARK_FRONTEND_PORT:-13000}
+      - WEBAUTHN_ORIGINS=http://localhost:${ISTARA_BENCHMARK_FRONTEND_PORT:-13000},http://127.0.0.1:${ISTARA_BENCHMARK_FRONTEND_PORT:-13000}
+      - AUTORESEARCH_ENABLED=${AUTORESEARCH_ENABLED:-false}
+      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+      - ISTARA_DISABLE_BACKGROUND_AGENTS=${ISTARA_BENCHMARK_DISABLE_BACKGROUND_AGENTS:-false}
+      - OLLAMA_HOST=${ISTARA_BENCHMARK_SERVER_OLLAMA_HOST:-http://ollama:11434}
+      - OLLAMA_MODEL=${ISTARA_BENCHMARK_LLM_MODEL:-qwen3:latest}
+    networks:
+      backend-net:
+      data-net:
+      frontend-net:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    deploy:
+      resources:
+        limits:
+          pids: 200
+
+  frontend:
+    container_name: istara-benchmark-frontend
+    ports:
+      - "${ISTARA_BENCHMARK_FRONTEND_PORT:-13000}:3000"
+    build:
+      args:
+        - NEXT_PUBLIC_API_URL=http://localhost:${ISTARA_BENCHMARK_API_PORT:-18000}
+        - NEXT_PUBLIC_WS_URL=ws://localhost:${ISTARA_BENCHMARK_API_PORT:-18000}
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:${ISTARA_BENCHMARK_API_PORT:-18000}
+      - NEXT_PUBLIC_WS_URL=ws://localhost:${ISTARA_BENCHMARK_API_PORT:-18000}
+    deploy:
+      resources:
+        limits:
+          pids: 100
+
+volumes:
+  istara_benchmark_ollama:
+  istara_benchmark_backend_data:
+  istara_benchmark_watch:

--- a/tests/real_user_benchmark/lib/api-client.mjs
+++ b/tests/real_user_benchmark/lib/api-client.mjs
@@ -1,0 +1,243 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+function parseEnvFileValue(content, key) {
+  const line = content.split(/\r?\n/).find((entry) => entry.trim().startsWith(`${key}=`));
+  if (!line) return "";
+  return line.slice(line.indexOf("=") + 1).trim().replace(/^["']|["']$/g, "");
+}
+
+export class IstaraApiClient {
+  constructor({ apiBase, repoRoot, logger, networkAccessToken = "", adminUsername = "", adminPassword = "" }) {
+    this.apiBase = apiBase.replace(/\/$/, "");
+    this.repoRoot = repoRoot;
+    this.logger = logger;
+    this.token = "";
+    this.userId = "";
+    this.networkAccessToken = networkAccessToken;
+    this.adminUsername = adminUsername;
+    this.adminPassword = adminPassword;
+  }
+
+  headers(extra = {}) {
+    const headers = { "Content-Type": "application/json", ...extra };
+    if (this.networkAccessToken) headers["X-Access-Token"] = this.networkAccessToken;
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    return headers;
+  }
+
+  async request(method, path, body = undefined, options = {}) {
+    const started = Date.now();
+    const controller = options.timeoutMs ? new AbortController() : null;
+    let timeout = null;
+    if (controller) {
+      timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+    }
+    try {
+      const response = await fetch(`${this.apiBase}${path}`, {
+        method,
+        headers: options.headers || this.headers(),
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller?.signal,
+      });
+      const text = await response.text();
+      const contentType = response.headers.get("content-type") || "";
+      let data = text;
+      if (contentType.includes("application/json") && text) {
+        data = JSON.parse(text);
+      }
+      this.logger?.action("api.request", {
+        method,
+        path,
+        status: response.status,
+        ok: response.ok,
+        duration_ms: Date.now() - started,
+      });
+      if (!response.ok) {
+        const detail = typeof data === "object" ? JSON.stringify(data).slice(0, 500) : String(data).slice(0, 500);
+        throw new Error(`${method} ${path}: ${response.status} ${detail}`);
+      }
+      return data || {};
+    } catch (error) {
+      this.logger?.action("api.error", {
+        method,
+        path,
+        duration_ms: Date.now() - started,
+        error: error.message,
+      });
+      throw error;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  get(path, options) {
+    return this.request("GET", path, undefined, options);
+  }
+
+  post(path, body, options) {
+    return this.request("POST", path, body, options);
+  }
+
+  patch(path, body, options) {
+    return this.request("PATCH", path, body, options);
+  }
+
+  delete(path, options) {
+    return this.request("DELETE", path, undefined, options);
+  }
+
+  async health() {
+    try {
+      const response = await fetch(`${this.apiBase}/api/health`);
+      return { ok: response.ok, status: response.status, data: response.ok ? await response.json().catch(() => ({})) : {} };
+    } catch (error) {
+      return { ok: false, status: 0, error: error.message };
+    }
+  }
+
+  async authenticate() {
+    const username = this.adminUsername || process.env.ISTARA_BENCHMARK_ADMIN_USERNAME || process.env.ISTARA_ADMIN_USERNAME || process.env.ADMIN_USERNAME || "admin";
+    const envFiles = [
+      join(this.repoRoot, "backend", ".env.local"),
+      join(this.repoRoot, "backend", ".env"),
+      join(this.repoRoot, ".env.local"),
+      join(this.repoRoot, ".env"),
+    ];
+    let password = this.adminPassword || process.env.ISTARA_BENCHMARK_ADMIN_PASSWORD || process.env.ISTARA_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD || "";
+    for (const path of envFiles) {
+      if (password) break;
+      try {
+        password = parseEnvFileValue(readFileSync(path, "utf8"), "ADMIN_PASSWORD");
+      } catch {}
+    }
+
+    if (password) {
+      try {
+        const result = await this.post("/api/auth/login", { username, password });
+        this.token = result.access_token || result.token || "";
+        this.userId = result.user?.id || result.user_id || username;
+        if (this.token) return { ok: true, method: "password", user_id: this.userId };
+      } catch (error) {
+        this.logger?.issue({
+          area: "auth",
+          severity: "low",
+          title: "Password auth failed during benchmark setup",
+          detail: error.message,
+        });
+      }
+    }
+
+    if (!["1", "true", "yes"].includes(String(process.env.ISTARA_E2E_ALLOW_LOCAL_TOKEN || "").toLowerCase())) {
+      return { ok: false, method: "none", reason: "No credentials and local signed token disabled." };
+    }
+
+    const script = [
+      "import sys",
+      `sys.path.insert(0, ${JSON.stringify(join(this.repoRoot, "backend"))})`,
+      "from app.core.auth import create_token",
+      `print(create_token("benchmark-admin", ${JSON.stringify(username)}, "admin", mfa_verified=True))`,
+    ].join("\n");
+    for (const pythonBin of [process.env.PYTHON, process.env.PYTHON_EXECUTABLE, "python3", "python"].filter(Boolean)) {
+      const result = spawnSync(pythonBin, ["-c", script], {
+        cwd: this.repoRoot,
+        encoding: "utf8",
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.status === 0 && result.stdout.trim()) {
+        this.token = result.stdout.trim();
+        this.userId = "benchmark-admin";
+        return { ok: true, method: "local-signed-token", user_id: this.userId };
+      }
+    }
+    return { ok: false, method: "local-signed-token", reason: "Could not mint local token." };
+  }
+
+  async uploadFile(projectId, filePath, fileName) {
+    const fileData = readFileSync(filePath);
+    const formData = new FormData();
+    formData.append("file", new Blob([fileData]), fileName);
+    const headers = {};
+    if (this.networkAccessToken) headers["X-Access-Token"] = this.networkAccessToken;
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    const response = await fetch(`${this.apiBase}/api/files/upload/${projectId}`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+    const text = await response.text();
+    let data = text;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {}
+    this.logger?.action("api.upload", {
+      path: `/api/files/upload/${projectId}`,
+      file_name: fileName,
+      status: response.status,
+      ok: response.ok,
+    });
+    if (!response.ok) throw new Error(`Upload ${fileName}: ${response.status} ${String(text).slice(0, 300)}`);
+    return data;
+  }
+
+  async sendChat({ projectId, message, sessionId = null, maxHistory = 30, timeoutMs = 240000 }) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const started = Date.now();
+    try {
+      const response = await fetch(`${this.apiBase}/api/chat`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({
+          project_id: projectId,
+          message,
+          session_id: sessionId,
+          include_history: true,
+          max_history: maxHistory,
+        }),
+        signal: controller.signal,
+      });
+      const raw = await response.text();
+      if (!response.ok) throw new Error(`POST /api/chat: ${response.status} ${raw.slice(0, 300)}`);
+      const parsed = parseSse(raw);
+      if (parsed.errors.length) {
+        throw new Error(`POST /api/chat SSE error: ${parsed.errors.join(" | ").slice(0, 500)}`);
+      }
+      return {
+        ok: true,
+        duration_ms: Date.now() - started,
+        raw,
+        content: parsed.content,
+        events: parsed.events,
+        errors: parsed.errors,
+        session_id: parsed.session_id || sessionId,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function parseSse(raw) {
+  const events = [];
+  const errors = [];
+  let content = "";
+  let sessionId = "";
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const body = line.slice(5).trim();
+    if (!body || body === "[DONE]") continue;
+    try {
+      const event = JSON.parse(body);
+      events.push(event);
+      if (event.type === "chunk" && event.content) content += event.content;
+      if (event.type === "error") errors.push(event.message || JSON.stringify(event));
+      if (event.session_id) sessionId = event.session_id;
+    } catch {
+      content += body;
+    }
+  }
+  return { events, errors, content, session_id: sessionId };
+}

--- a/tests/real_user_benchmark/lib/corpus.mjs
+++ b/tests/real_user_benchmark/lib/corpus.mjs
@@ -1,0 +1,439 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { basename, join } from "path";
+import { spawnSync } from "child_process";
+
+export const PROJECT_CONTEXT = {
+  name: "CareNav Renewal",
+  company: "Northstar Health",
+  audience: "care coordinators, patients, family caregivers, and clinic administrators",
+  product: "a patient-care coordination workspace for appointment prep, reminders, and task follow-up",
+  stage: "mid-fidelity redesign after a failed pilot",
+  guardrails: [
+    "Do not infer medical advice.",
+    "Treat patient stories as synthetic PHI-like data and avoid exposing names in reports.",
+    "Separate staff workflow evidence from patient/caregiver evidence.",
+    "Flag contradictions and missing sampling context.",
+    "Prefer source-cited recommendations over generic UX advice.",
+  ],
+  researchQuestions: [
+    "Where does appointment-prep coordination break down?",
+    "Which reminders feel supportive versus nagging?",
+    "What does staff need to trust automation?",
+    "How should caregiver involvement be represented without confusing consent?",
+  ],
+};
+
+const participants = [
+  ["P01", "Marta", "care coordinator", "rural clinic", "Portuguese bilingual"],
+  ["P02", "Leo", "patient", "diabetes follow-up", "mobile-first"],
+  ["P03", "Asha", "caregiver", "elder care", "limited portal access"],
+  ["P04", "Nina", "nurse manager", "urban clinic", "dashboard owner"],
+  ["P05", "Owen", "patient", "post-op prep", "low confidence"],
+  ["P06", "Ravi", "care coordinator", "specialty clinic", "high caseload"],
+  ["P07", "Elena", "caregiver", "Spanish bilingual", "shared device"],
+  ["P08", "Sam", "clinic admin", "pilot sponsor", "data governance"],
+  ["P09", "Priya", "patient", "fertility consult", "privacy sensitive"],
+  ["P10", "Jon", "care coordinator", "pediatrics", "paper workaround"],
+  ["P11", "Beatriz", "patient", "cardiology", "Portuguese notes"],
+  ["P12", "Camila", "caregiver", "oncology", "high anxiety"],
+  ["P13", "Hannah", "care coordinator", "community health", "SMS-heavy workflow"],
+  ["P14", "Andre", "patient", "Spanish follow-up", "missed labs"],
+  ["P15", "Monique", "nurse", "handoff lead", "EHR constraints"],
+  ["P16", "Iris", "patient", "first-time portal user", "accessibility needs"],
+  ["P17", "Diego", "caregiver", "multi-household", "permissions confusion"],
+  ["P18", "Kai", "operations analyst", "analytics owner", "source of metrics"],
+];
+
+const painPoints = [
+  "patients cannot tell which tasks are required before the appointment",
+  "staff duplicate reminders in SMS, portal messages, and sticky notes",
+  "caregivers receive partial information and then call the clinic",
+  "the dashboard hides stale tasks until the day before a visit",
+  "forms look complete even when lab attachments are missing",
+  "Spanish and Portuguese copy is inconsistent across reminders",
+  "staff do not trust automation when no source trail is shown",
+  "patients miss reminders sent during working hours",
+];
+
+const opportunities = [
+  "show a preparation timeline with required, optional, and blocked steps",
+  "surface the source and freshness of each task",
+  "give coordinators a one-click reason for overriding automation",
+  "create a caregiver-safe view with explicit permission labels",
+  "collapse duplicate reminders into a single communication history",
+  "add confidence labels when evidence is incomplete",
+  "summarize appointment readiness without medical interpretation",
+  "let staff filter by next patient action instead of visit date only",
+];
+
+function writeFile(root, relPath, content) {
+  const path = join(root, relPath);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  return {
+    path,
+    file_name: basename(path),
+    relative_path: relPath,
+    bytes: Buffer.byteLength(content),
+  };
+}
+
+function interviewTranscript(index, participant) {
+  const [id, name, role, segment, note] = participant;
+  const pain = painPoints[index % painPoints.length];
+  const secondPain = painPoints[(index + 3) % painPoints.length];
+  const opportunity = opportunities[index % opportunities.length];
+  return [
+    `# Interview ${id}: ${role} - ${segment}`,
+    "",
+    `Participant: ${name}`,
+    `Context: ${note}`,
+    `Date: 2026-04-${String((index % 24) + 1).padStart(2, "0")}`,
+    "Moderator: Maya Rodrigues",
+    "",
+    "## Transcript",
+    `[00:00] Maya: Thanks for joining. I am trying to understand how appointment preparation works from your perspective.`,
+    `[00:31] ${name}: The biggest thing is that ${pain}.`,
+    `[01:24] Maya: Can you walk me through the last time that happened?`,
+    `[02:02] ${name}: We had a visit where the portal said everything was ready, but ${secondPain}. I only noticed because someone called.`,
+    `[03:18] Maya: What did you do next?`,
+    `[03:51] ${name}: I made a note outside the system. That is risky, but it is faster than searching three places.`,
+    `[05:09] Maya: What would make the system trustworthy?`,
+    `[05:42] ${name}: I need to see why it thinks a task is ready. A status alone is not enough.`,
+    `[07:00] Maya: If you could change one thing, what would it be?`,
+    `[07:33] ${name}: ${opportunity}. Then I would not need to keep my own tracker.`,
+    "",
+    "## Researcher memo",
+    `Evidence strength: ${index % 4 === 0 ? "high" : "medium"}.`,
+    `Potential contradiction: ${index % 3 === 0 ? "participant says reminders are too frequent, but analytics show low open rates" : "none noted"}.`,
+  ].join("\n");
+}
+
+function usabilityReport(index) {
+  const scenario = [
+    "Prepare for a cardiology follow-up",
+    "Invite a caregiver to review tasks",
+    "Resolve a missing lab attachment",
+    "Override an automated reminder",
+    "Find patients blocked by unanswered forms",
+    "Explain appointment readiness to a nurse",
+  ][index % 6];
+  const completion = 58 + ((index * 7) % 35);
+  return [
+    `# Usability Test U${String(index + 1).padStart(2, "0")}`,
+    "",
+    `Scenario: ${scenario}`,
+    `Prototype: CareNav v${index % 2 === 0 ? "A" : "B"}`,
+    `Participants: ${6 + (index % 3)}`,
+    "",
+    "| Task | Completion | Median Time | Notes |",
+    "| --- | ---: | ---: | --- |",
+    `| Locate blocked tasks | ${completion}% | ${90 + index * 8}s | Users scanned visit dates before task status |`,
+    `| Identify missing evidence | ${completion - 11}% | ${120 + index * 11}s | Source trail label was missed by 4 participants |`,
+    `| Send caregiver-safe update | ${completion - 18}% | ${150 + index * 9}s | Permission wording caused hesitation |`,
+    "",
+    "## Observed friction",
+    `- ${painPoints[index % painPoints.length]}.`,
+    `- ${painPoints[(index + 5) % painPoints.length]}.`,
+    "- Users expected a plain-language readiness reason next to the status.",
+    "",
+    "## Moderator recommendations",
+    `- ${opportunities[index % opportunities.length]}.`,
+    "- Test permission copy with caregivers before expanding the flow.",
+  ].join("\n");
+}
+
+function diaryStudy() {
+  const lines = ["participant_id,day,role,event,emotion,quote"];
+  for (let p = 1; p <= 10; p += 1) {
+    for (let day = 1; day <= 5; day += 1) {
+      const pain = painPoints[(p + day) % painPoints.length];
+      const emotion = ["confident", "confused", "rushed", "relieved", "skeptical"][(p + day) % 5];
+      lines.push(`D${String(p).padStart(2, "0")},${day},${participants[p % participants.length][2]},appointment prep,${emotion},"Today ${pain}; I wrote a workaround note."`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function surveyCsv() {
+  const headers = [
+    "respondent_id",
+    "role",
+    "language",
+    "clinic_type",
+    "readiness_trust",
+    "reminder_clarity",
+    "caregiver_confidence",
+    "time_saved_minutes",
+    "nps",
+    "open_feedback",
+  ];
+  const rows = [headers.join(",")];
+  const roles = ["patient", "caregiver", "care coordinator", "nurse manager", "clinic admin"];
+  const languages = ["en", "en", "es", "pt-BR"];
+  for (let i = 1; i <= 320; i += 1) {
+    const role = roles[i % roles.length];
+    const trust = 2 + (i % 4);
+    const clarity = 1 + ((i * 3) % 5);
+    const caregiver = 1 + ((i * 5) % 5);
+    const saved = (i * 7) % 45;
+    const nps = (i * 9) % 11;
+    const feedback = `${painPoints[i % painPoints.length]} but ${opportunities[(i + 2) % opportunities.length]}`;
+    rows.push([
+      `R${String(i).padStart(3, "0")}`,
+      role,
+      languages[i % languages.length],
+      i % 3 === 0 ? "community" : "specialty",
+      trust,
+      clarity,
+      caregiver,
+      saved,
+      nps,
+      `"${feedback}"`,
+    ].join(","));
+  }
+  return rows.join("\n");
+}
+
+function analyticsCsv() {
+  const rows = ["week,portal_task_open_rate,sms_click_rate,missed_prep_rate,staff_override_rate,avg_minutes_per_case"];
+  for (let week = 1; week <= 16; week += 1) {
+    rows.push([
+      `2026-W${String(week).padStart(2, "0")}`,
+      (0.41 + week * 0.01).toFixed(2),
+      (0.28 + (week % 5) * 0.03).toFixed(2),
+      (0.38 - week * 0.008).toFixed(2),
+      (0.12 + (week % 4) * 0.02).toFixed(2),
+      18 + (week % 6),
+    ].join(","));
+  }
+  return rows.join("\n");
+}
+
+function supportTicketsJsonl() {
+  const lines = [];
+  for (let i = 1; i <= 160; i += 1) {
+    lines.push(JSON.stringify({
+      ticket_id: `T-${String(i).padStart(4, "0")}`,
+      channel: ["phone", "portal", "sms", "front desk"][i % 4],
+      role: ["patient", "caregiver", "care coordinator"][i % 3],
+      severity: ["low", "medium", "high"][i % 3],
+      summary: painPoints[i % painPoints.length],
+      resolution: i % 5 === 0 ? "manual follow-up required" : "answered with workaround",
+      tags: ["prep", "reminder", i % 2 === 0 ? "caregiver" : "staff"],
+    }));
+  }
+  return lines.join("\n");
+}
+
+function competitorNotes() {
+  return [
+    "# Competitor Review Notes",
+    "",
+    "| Competitor | Strong Pattern | Weak Pattern | Implication |",
+    "| --- | --- | --- | --- |",
+    "| WellPath Tasks | Clear readiness timeline | No caregiver permission labels | Timeline is valuable, but privacy language matters |",
+    "| ClinicFlow | Staff override reason is captured | Patient view is buried | Trust grows when staff decisions are visible |",
+    "| RemindRx | SMS reminders are concise | No source trail for tasks | Concision helps, missing evidence hurts adoption |",
+    "| CareBridge | Caregiver roles are explicit | Setup is long | Permission framing should be progressive |",
+  ].join("\n");
+}
+
+function multilingualExamples() {
+  return [
+    "# Multilingual Reminder Examples",
+    "",
+    "## Portuguese",
+    "Paciente: Nao entendi se o exame de sangue e obrigatorio antes da consulta. A mensagem parecia opcional.",
+    "Cuidadora: Recebi o lembrete, mas nao tenho permissao para ver o anexo.",
+    "",
+    "## Spanish",
+    "Paciente: La aplicacion dijo que todo estaba listo, pero la clinica llamo por un formulario pendiente.",
+    "Cuidador: Necesito saber que puedo hacer sin ver informacion privada.",
+  ].join("\n");
+}
+
+function malformedFile() {
+  return [
+    "participant_id,role,quote",
+    "M01,patient,\"The reminder said ready",
+    "M02,caregiver,missing closing quote and extra field,unexpected",
+    "\u0000\u0001bad-bytes-represented-as-text",
+    "M03,,blank role should be handled",
+  ].join("\n");
+}
+
+function writeMinimalPptx(root, relPath) {
+  const temp = join(root, ".pptx-tmp");
+  rmSync(temp, { recursive: true, force: true });
+  mkdirSync(join(temp, "_rels"), { recursive: true });
+  mkdirSync(join(temp, "ppt", "_rels"), { recursive: true });
+  mkdirSync(join(temp, "ppt", "slides", "_rels"), { recursive: true });
+  mkdirSync(join(temp, "ppt", "slides"), { recursive: true });
+  writeFileSync(join(temp, "[Content_Types].xml"), `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>`);
+  writeFileSync(join(temp, "_rels", ".rels"), `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`);
+  writeFileSync(join(temp, "ppt", "presentation.xml"), `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst><p:sldSz cx="12192000" cy="6858000" type="screen16x9"/></p:presentation>`);
+  writeFileSync(join(temp, "ppt", "_rels", "presentation.xml.rels"), `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>`);
+  writeFileSync(join(temp, "ppt", "slides", "slide1.xml"), `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>CareNav Renewal Research Readout</a:t></a:r></a:p><a:p><a:r><a:t>Key risk: readiness status lacks source trust.</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>`);
+  const outPath = join(root, relPath);
+  mkdirSync(join(outPath, ".."), { recursive: true });
+  const result = spawnSync("zip", ["-qr", outPath, "."], { cwd: temp, encoding: "utf8" });
+  rmSync(temp, { recursive: true, force: true });
+  if (result.status !== 0 || !existsSync(outPath)) {
+    return writeFile(root, relPath.replace(/\.pptx$/, ".pptx.txt"), "PPTX fallback: CareNav Renewal Research Readout\nKey risk: readiness status lacks source trust.\n");
+  }
+  return {
+    path: outPath,
+    file_name: basename(outPath),
+    relative_path: relPath,
+    bytes: 0,
+    generated_with: "minimal-openxml-zip",
+  };
+}
+
+export function generateCorpus({ outputDir, logger }) {
+  mkdirSync(outputDir, { recursive: true });
+  const manifest = [];
+
+  manifest.push(writeFile(outputDir, "00-project-context.md", [
+    `# ${PROJECT_CONTEXT.name}`,
+    "",
+    `Company: ${PROJECT_CONTEXT.company}`,
+    `Audience: ${PROJECT_CONTEXT.audience}`,
+    `Product: ${PROJECT_CONTEXT.product}`,
+    `Stage: ${PROJECT_CONTEXT.stage}`,
+    "",
+    "## Guardrails",
+    ...PROJECT_CONTEXT.guardrails.map((item) => `- ${item}`),
+    "",
+    "## Research Questions",
+    ...PROJECT_CONTEXT.researchQuestions.map((item) => `- ${item}`),
+  ].join("\n")));
+
+  participants.forEach((participant, index) => {
+    manifest.push(writeFile(outputDir, `interviews/${participant[0]}-${participant[2].replace(/\s+/g, "-")}.md`, interviewTranscript(index, participant)));
+  });
+
+  for (let i = 0; i < 6; i += 1) {
+    manifest.push(writeFile(outputDir, `usability/usability-test-${String(i + 1).padStart(2, "0")}.md`, usabilityReport(i)));
+  }
+
+  manifest.push(writeFile(outputDir, "surveys/carenav-survey-180.csv", surveyCsv()));
+  manifest.push(writeFile(outputDir, "diary/diary-study-week.csv", diaryStudy()));
+  manifest.push(writeFile(outputDir, "analytics/pilot-analytics.csv", analyticsCsv()));
+  manifest.push(writeFile(outputDir, "support/support-tickets.jsonl", supportTicketsJsonl()));
+  manifest.push(writeFile(outputDir, "competitive/competitor-notes.md", competitorNotes()));
+  manifest.push(writeFile(outputDir, "design/design-critique-notes.md", [
+    "# Design Critique Notes",
+    "",
+    "- Readiness badge looks definitive even when evidence is stale.",
+    "- Staff need a visible override reason before trusting automated reminders.",
+    "- Caregiver panel uses the same visual hierarchy as patient tasks, causing role confusion.",
+    "- The timeline prototype scored better than the checklist prototype in scan tests.",
+  ].join("\n")));
+  manifest.push(writeFile(outputDir, "field-notes/clinic-shadowing.md", [
+    "# Clinic Shadowing Field Notes",
+    "",
+    "Morning huddle: three coordinators compared portal tasks with handwritten notes.",
+    "One nurse said the team trusts the sticky note because it has a person's initials.",
+    "A caregiver called twice about a lab form that was complete in one system but missing in another.",
+    "Staff asked for a readiness queue grouped by next action, not appointment date.",
+  ].join("\n")));
+  for (let i = 1; i <= 8; i += 1) {
+    manifest.push(writeFile(outputDir, `stakeholder-memos/stakeholder-memo-${String(i).padStart(2, "0")}.md`, [
+      `# Stakeholder Memo ${i}`,
+      "",
+      `Owner: ${["Operations", "Clinical Safety", "Patient Experience", "Compliance"][i % 4]}`,
+      `Decision pressure: ${painPoints[(i + 2) % painPoints.length]}.`,
+      "",
+      "## Position",
+      `The stakeholder believes the redesign should prioritize ${opportunities[(i + 1) % opportunities.length]}.`,
+      "",
+      "## Tension",
+      `This may conflict with ${opportunities[(i + 4) % opportunities.length]} because teams have different views of readiness ownership.`,
+      "",
+      "## Evidence requested",
+      "- More separation between patient, caregiver, and staff workflows.",
+      "- Stronger proof that source trails reduce support calls.",
+      "- A clear privacy review before caregiver-facing launch.",
+    ].join("\n")));
+  }
+  for (let i = 1; i <= 12; i += 1) {
+    manifest.push(writeFile(outputDir, `experiments/concept-test-${String(i).padStart(2, "0")}.md`, [
+      `# Concept Test ${i}`,
+      "",
+      `Concept: ${["Timeline", "Checklist", "Readiness Score", "Caregiver Card"][i % 4]}`,
+      `Stimulus: mid-fidelity screen set ${String.fromCharCode(64 + ((i % 4) + 1))}`,
+      "",
+      "## What worked",
+      `- ${opportunities[i % opportunities.length]}.`,
+      "- Participants understood required versus optional labels faster than status-only labels.",
+      "",
+      "## What failed",
+      `- ${painPoints[(i + 1) % painPoints.length]}.`,
+      "- Confidence labels were interpreted as medical confidence by two participants.",
+      "",
+      "## Follow-up needed",
+      "- Test whether 'source freshness' reads as data freshness rather than clinical recency.",
+    ].join("\n")));
+  }
+  for (let i = 1; i <= 10; i += 1) {
+    manifest.push(writeFile(outputDir, `call-center/call-snippet-${String(i).padStart(2, "0")}.txt`, [
+      `Call ${i}`,
+      `Caller role: ${["patient", "caregiver", "care coordinator"][i % 3]}`,
+      `Issue: ${painPoints[(i + 5) % painPoints.length]}.`,
+      `Quote: "I do not need another reminder. I need to know which thing is actually blocking the visit."`,
+      `Disposition: ${i % 2 === 0 ? "escalated to coordinator" : "resolved with manual explanation"}`,
+    ].join("\n")));
+  }
+  for (let i = 1; i <= 6; i += 1) {
+    manifest.push(writeFile(outputDir, `privacy/consent-review-${String(i).padStart(2, "0")}.md`, [
+      `# Consent Review ${i}`,
+      "",
+      "Risk area: caregiver access and reminder content.",
+      `Observed issue: ${painPoints[(i + 6) % painPoints.length]}.`,
+      "Guidance: do not reveal clinical details in caregiver-safe reminders unless permission is explicit.",
+      "Research implication: evaluate whether role labels are understood before expanding automated outreach.",
+    ].join("\n")));
+  }
+  manifest.push(writeFile(outputDir, "multilingual/pt-es-reminder-examples.md", multilingualExamples()));
+  manifest.push(writeFile(outputDir, "edge-cases/malformed-survey-export.csv", malformedFile()));
+  manifest.push(writeFile(outputDir, "web/url-fetch-targets.md", [
+    "# URL Fetch Targets for Benchmark",
+    "",
+    "Use these URLs in chat and task prompts to test graceful web fetching:",
+    "- https://example.com/healthcare-coordination-benchmark",
+    "- https://www.nngroup.com/articles/service-blueprints-definition/",
+    "- https://www.w3.org/WAI/WCAG22/quickref/",
+  ].join("\n")));
+  manifest.push(writeMinimalPptx(outputDir, "presentations/carenav-readout.pptx"));
+
+  const summary = {
+    project: PROJECT_CONTEXT,
+    generated_at: new Date().toISOString(),
+    document_count: manifest.length,
+    total_bytes: manifest.reduce((sum, item) => sum + (item.bytes || 0), 0),
+    manifest,
+  };
+  writeFileSync(join(outputDir, "corpus-manifest.json"), JSON.stringify(summary, null, 2));
+  logger?.action("corpus.generated", {
+    document_count: summary.document_count,
+    total_bytes: summary.total_bytes,
+    output_dir: outputDir,
+  });
+  return summary;
+}

--- a/tests/real_user_benchmark/lib/integration-discovery.mjs
+++ b/tests/real_user_benchmark/lib/integration-discovery.mjs
@@ -1,0 +1,248 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+export const CLASSIFICATIONS = {
+  live: "live-tested",
+  harness: "developer-harness-tested",
+  setup: "setup-error-path-tested",
+  blocked: "blocked-no-test-harness",
+  missing: "not-implemented",
+};
+
+function fileContains(repoRoot, relPath, pattern) {
+  const path = join(repoRoot, relPath);
+  if (!existsSync(path)) return false;
+  return pattern.test(readFileSync(path, "utf8"));
+}
+
+export function discoverStaticHarnesses(repoRoot) {
+  return {
+    stitch: {
+      hasMockEndpoints: fileContains(repoRoot, "backend/app/api/routes/interfaces_mock.py", /interfaces\/mock\/generate/),
+      hasLiveRoute: fileContains(repoRoot, "backend/app/api/routes/interfaces_screens.py", /interfaces\/screens\/generate/),
+    },
+    figma: {
+      hasMockImport: fileContains(repoRoot, "backend/app/api/routes/interfaces_mock.py", /figma-import/),
+      hasLiveRoute: fileContains(repoRoot, "backend/app/api/routes/interfaces_integrations.py", /figma/i),
+    },
+    surveys: {
+      hasDemoBySimPrefix: fileContains(repoRoot, "backend/app/api/routes/surveys.py", /_is_demo_integration/),
+      supportsTypeform: fileContains(repoRoot, "backend/app/api/routes/surveys.py", /typeform/),
+      supportsSurveyMonkey: fileContains(repoRoot, "backend/app/api/routes/surveys.py", /surveymonkey/),
+      supportsGoogleForms: fileContains(repoRoot, "backend/app/api/routes/surveys.py", /google_forms/),
+    },
+    telegram: {
+      hasAdapter: fileContains(repoRoot, "backend/app/channels/telegram.py", /class TelegramAdapter/),
+      hasChannelRoutes: fileContains(repoRoot, "backend/app/api/routes/channels.py", /channels\/\{instance_id\}\/start/),
+    },
+    aura: {
+      hasDeployments: fileContains(repoRoot, "backend/app/api/routes/deployments.py", /deployments\/\{deployment_id\}\/respond/),
+      hasConversationCreateApi: fileContains(repoRoot, "backend/app/api/routes/deployments.py", /post\(.+conversations/),
+    },
+    mcp: {
+      hasRoutes: fileContains(repoRoot, "backend/app/api/routes/mcp.py", /mcp\/server\/status/),
+      hasClientRoutes: fileContains(repoRoot, "backend/app/api/routes/mcp.py", /mcp\/clients/),
+    },
+  };
+}
+
+async function attempt(logger, integration, action, fn) {
+  const started = Date.now();
+  try {
+    const result = await fn();
+    logger.integrationAttempt({
+      integration,
+      action,
+      ok: true,
+      duration_ms: Date.now() - started,
+      result: summarize(result),
+    });
+    return { ok: true, result };
+  } catch (error) {
+    logger.integrationAttempt({
+      integration,
+      action,
+      ok: false,
+      duration_ms: Date.now() - started,
+      error: error.message,
+    });
+    return { ok: false, error: error.message };
+  }
+}
+
+function summarize(value) {
+  if (value === undefined) return {};
+  if (typeof value === "string") return value.slice(0, 500);
+  return JSON.parse(JSON.stringify(value, (_key, val) => {
+    if (typeof val === "string" && val.length > 300) return `${val.slice(0, 300)}...`;
+    return val;
+  }));
+}
+
+export async function runIntegrationMatrix({ api, projectId, repoRoot, logger }) {
+  const staticHarnesses = discoverStaticHarnesses(repoRoot);
+  logger.writeJson("integration-static-discovery.json", staticHarnesses);
+  const matrix = [];
+
+  const interfaceStatus = await attempt(logger, "interfaces", "GET /api/interfaces/status", () => api.get("/api/interfaces/status"));
+
+  let stitchClass = staticHarnesses.stitch.hasMockEndpoints ? CLASSIFICATIONS.harness : CLASSIFICATIONS.missing;
+  const stitchGenerate = await attempt(logger, "google_stitch", "POST /api/interfaces/mock/generate", () => api.post("/api/interfaces/mock/generate", {
+    project_id: projectId,
+    prompt: "CareNav readiness timeline with source confidence and caregiver-safe permissions",
+    device_type: "DESKTOP",
+  }));
+  if (!stitchGenerate.ok) stitchClass = staticHarnesses.stitch.hasLiveRoute ? CLASSIFICATIONS.setup : CLASSIFICATIONS.blocked;
+  matrix.push({
+    integration: "Google Stitch",
+    classification: stitchGenerate.ok ? CLASSIFICATIONS.harness : stitchClass,
+    evidence: { static: staticHarnesses.stitch, status: interfaceStatus.result, attempt: stitchGenerate },
+  });
+
+  let screenId = stitchGenerate.result?.id;
+  if (screenId) {
+    await attempt(logger, "google_stitch", "POST /api/interfaces/mock/edit", () => api.post("/api/interfaces/mock/edit", {
+      screen_id: screenId,
+      instructions: "Add a source freshness warning for stale lab tasks.",
+    }));
+    await attempt(logger, "google_stitch", "POST /api/interfaces/mock/variants", () => api.post("/api/interfaces/mock/variants", {
+      screen_id: screenId,
+      variant_type: "REFINE",
+      count: 2,
+    }));
+  }
+
+  const figmaImport = await attempt(logger, "figma", "POST /api/interfaces/mock/figma-import", () => api.post("/api/interfaces/mock/figma-import", {
+    project_id: projectId,
+    figma_url: "https://www.figma.com/file/fake-benchmark/CareNav?node-id=1-2",
+  }));
+  matrix.push({
+    integration: "Figma",
+    classification: figmaImport.ok ? CLASSIFICATIONS.harness : (staticHarnesses.figma.hasLiveRoute ? CLASSIFICATIONS.setup : CLASSIFICATIONS.blocked),
+    evidence: { static: staticHarnesses.figma, attempt: figmaImport },
+  });
+
+  for (const survey of [
+    ["Typeform", "typeform", { api_token: "sim-typeform-token" }],
+    ["SurveyMonkey", "surveymonkey", { access_token: "sim-surveymonkey-token" }],
+    ["Google Forms", "google_forms", { service_account_json: "{}" }],
+  ]) {
+    const [label, platform, config] = survey;
+    const created = await attempt(logger, label, "POST /api/surveys/integrations", () => api.post("/api/surveys/integrations", {
+      platform,
+      name: `SIM: Real User Benchmark ${label}`,
+      config,
+      project_id: projectId,
+    }));
+    let classification = created.ok && staticHarnesses.surveys.hasDemoBySimPrefix ? CLASSIFICATIONS.harness : CLASSIFICATIONS.setup;
+    let link = null;
+    if (created.ok) {
+      link = await attempt(logger, label, "POST /api/surveys/links", () => api.post("/api/surveys/links", {
+        integration_id: created.result.id,
+        project_id: projectId,
+        external_survey_id: `sim-${platform}-caregiver-readiness`,
+        external_survey_name: `SIM: ${label} caregiver readiness survey`,
+      }));
+      if (link.ok) {
+        await attempt(logger, label, "POST /api/surveys/links/{id}/sync", () => api.post(`/api/surveys/links/${link.result.id}/sync`, {}));
+        await attempt(logger, label, "GET /api/surveys/links/{id}/responses", () => api.get(`/api/surveys/links/${link.result.id}/responses`));
+      }
+    } else if (!staticHarnesses.surveys[`supports${label.replace(/\s/g, "")}`]) {
+      classification = CLASSIFICATIONS.missing;
+    }
+    matrix.push({
+      integration: label,
+      classification,
+      evidence: { static: staticHarnesses.surveys, created, link },
+    });
+  }
+
+  const telegram = await attempt(logger, "telegram", "POST /api/channels", () => api.post("/api/channels", {
+    platform: "telegram",
+    name: "SIM: Fake Telegram Bot",
+    config: { bot_token: "000000:fake-token-for-benchmark" },
+    project_id: projectId,
+  }));
+  let telegramClassification = telegram.ok ? CLASSIFICATIONS.setup : CLASSIFICATIONS.blocked;
+  if (telegram.ok) {
+    const start = await attempt(logger, "telegram", "POST /api/channels/{id}/start", () => api.post(`/api/channels/${telegram.result.id}/start`, {}));
+    const health = await attempt(logger, "telegram", "GET /api/channels/{id}/health", () => api.get(`/api/channels/${telegram.result.id}/health`));
+    telegramClassification = start.ok && start.result?.status === "started" ? CLASSIFICATIONS.live : CLASSIFICATIONS.setup;
+    matrix.push({
+      integration: "Telegram",
+      classification: telegramClassification,
+      evidence: { static: staticHarnesses.telegram, created: telegram, start, health },
+    });
+  } else {
+    matrix.push({
+      integration: "Telegram",
+      classification: telegramClassification,
+      evidence: { static: staticHarnesses.telegram, created: telegram },
+    });
+  }
+
+  const deployment = await attempt(logger, "aura", "POST /api/deployments", () => api.post("/api/deployments", {
+    project_id: projectId,
+    name: "SIM: AURA Appointment Prep Interview",
+    deployment_type: "interview",
+    questions: [
+      { text: "What made your last appointment prep easier or harder?", type: "open", expected_insight: "prep blockers" },
+      { text: "When did reminders feel useful versus annoying?", type: "open", expected_insight: "reminder trust" },
+      { text: "What would make caregiver involvement feel safe?", type: "open", expected_insight: "permission clarity" },
+    ],
+    channel_instance_ids: telegram.ok ? [telegram.result.id] : [],
+    config: {
+      adaptive: true,
+      adaptive_enabled: true,
+      max_followups: 2,
+      intro_message: "We are testing appointment-prep coordination.",
+      thank_you_message: "Thanks for helping improve CareNav.",
+    },
+    target_responses: 5,
+  }));
+  let auraClassification = deployment.ok ? CLASSIFICATIONS.setup : CLASSIFICATIONS.blocked;
+  if (deployment.ok) {
+    await attempt(logger, "aura", "POST /api/deployments/{id}/activate", () => api.post(`/api/deployments/${deployment.result.id}/activate`, {}));
+    const response = await attempt(logger, "aura", "POST /api/deployments/{id}/respond without conversation harness", () => api.post(`/api/deployments/${deployment.result.id}/respond`, {
+      conversation_id: "simulated-conversation-without-create-api",
+      message_text: "I missed my lab reminder because it came while I was at work.",
+    }));
+    if (response.ok && response.result?.action === "error") {
+      auraClassification = CLASSIFICATIONS.blocked;
+      logger.issue({
+        area: "Telegram/AURA",
+        severity: "high",
+        title: "AURA participant response simulation lacks credential-free conversation harness",
+        detail: "Deployment response endpoint requires an existing ChannelConversation, but the public routes do not expose a local simulator or conversation creation path.",
+        evidence: response.result,
+      });
+    }
+    matrix.push({
+      integration: "Telegram AURA research process",
+      classification: auraClassification,
+      evidence: { static: staticHarnesses.aura, deployment, response },
+    });
+  }
+
+  const mcpStatus = await attempt(logger, "mcp", "GET /api/mcp/server/status", () => api.get("/api/mcp/server/status"));
+  const mcpClients = await attempt(logger, "mcp", "GET /api/mcp/clients", () => api.get("/api/mcp/clients"));
+  const mcpClient = await attempt(logger, "mcp", "POST /api/mcp/clients fake HTTP", () => api.post("/api/mcp/clients", {
+    name: "SIM: Fake local HTTP MCP server",
+    transport: "http",
+    url: "http://127.0.0.1:9/mcp",
+    headers: { "X-Benchmark": "real-user" },
+  }));
+  let mcpClassification = mcpStatus.ok || mcpClients.ok ? CLASSIFICATIONS.setup : CLASSIFICATIONS.blocked;
+  if (mcpClient.ok) {
+    const discover = await attempt(logger, "mcp", "POST /api/mcp/clients/{id}/discover", () => api.post(`/api/mcp/clients/${mcpClient.result.id}/discover`, {}));
+    mcpClassification = discover.ok ? CLASSIFICATIONS.harness : CLASSIFICATIONS.setup;
+  }
+  matrix.push({
+    integration: "MCP",
+    classification: mcpClassification,
+    evidence: { static: staticHarnesses.mcp, status: mcpStatus, clients: mcpClients, fakeClient: mcpClient },
+  });
+
+  logger.writeJson("integration-matrix.json", matrix);
+  return matrix;
+}

--- a/tests/real_user_benchmark/lib/logger.mjs
+++ b/tests/real_user_benchmark/lib/logger.mjs
@@ -1,0 +1,142 @@
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export function makeRunId(now = new Date()) {
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+export class BenchmarkLogger {
+  constructor({ rootDir, runId, mode }) {
+    this.rootDir = rootDir;
+    this.runId = runId;
+    this.mode = mode;
+    this.runDir = join(rootDir, "runs", runId);
+    this.paths = {
+      logs: join(this.runDir, "logs"),
+      screenshots: join(this.runDir, "screenshots"),
+      traces: join(this.runDir, "traces"),
+      corpus: join(this.runDir, "corpus"),
+      uploads: join(this.runDir, "uploads"),
+      artifacts: join(this.runDir, "artifacts"),
+      network: join(this.runDir, "network"),
+      storage: join(this.runDir, "storage"),
+    };
+    this.issues = [];
+    this.metrics = {
+      actions: 0,
+      chatTurns: 0,
+      taskApprovals: 0,
+      taskRevisions: 0,
+      integrationAttempts: 0,
+      screenshots: 0,
+    };
+  }
+
+  init() {
+    mkdirSync(this.runDir, { recursive: true });
+    for (const dir of Object.values(this.paths)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    this.writeJson("run-metadata.json", {
+      run_id: this.runId,
+      mode: this.mode,
+      started_at: new Date().toISOString(),
+      cwd: process.cwd(),
+      node: process.version,
+    });
+  }
+
+  line(file, payload) {
+    const record = {
+      ts: new Date().toISOString(),
+      run_id: this.runId,
+      ...payload,
+    };
+    appendFileSync(join(this.runDir, file), `${JSON.stringify(record)}\n`);
+    return record;
+  }
+
+  action(step, payload = {}) {
+    this.metrics.actions += 1;
+    return this.line("action-log.jsonl", { step, ...payload });
+  }
+
+  chatTurn(payload) {
+    this.metrics.chatTurns += 1;
+    return this.line("conversation-turns.jsonl", payload);
+  }
+
+  taskReview(payload) {
+    if (payload.outcome === "approved") this.metrics.taskApprovals += 1;
+    if (payload.outcome === "revision_requested") this.metrics.taskRevisions += 1;
+    return this.line("task-review-log.jsonl", payload);
+  }
+
+  integrationAttempt(payload) {
+    this.metrics.integrationAttempts += 1;
+    return this.line("integration-attempts.jsonl", payload);
+  }
+
+  issue(issue) {
+    const item = {
+      ts: new Date().toISOString(),
+      severity: issue.severity || "medium",
+      area: issue.area || "benchmark",
+      title: issue.title,
+      detail: issue.detail || "",
+      evidence: issue.evidence || {},
+    };
+    this.issues.push(item);
+    this.line("issues.jsonl", item);
+    return item;
+  }
+
+  writeJson(relPath, payload) {
+    writeFileSync(join(this.runDir, relPath), JSON.stringify(payload, null, 2));
+  }
+
+  writeRootJson(relPath, payload) {
+    mkdirSync(this.rootDir, { recursive: true });
+    writeFileSync(join(this.rootDir, relPath), JSON.stringify(payload, null, 2));
+  }
+
+  rootLine(file, payload) {
+    mkdirSync(this.rootDir, { recursive: true });
+    const record = {
+      ts: new Date().toISOString(),
+      run_id: this.runId,
+      ...payload,
+    };
+    appendFileSync(join(this.rootDir, file), `${JSON.stringify(record)}\n`);
+    return record;
+  }
+
+  writeText(relPath, content) {
+    writeFileSync(join(this.runDir, relPath), content);
+  }
+
+  appendReport(content) {
+    appendFileSync(join(this.runDir, "report.md"), content);
+  }
+
+  noteScreenshot() {
+    this.metrics.screenshots += 1;
+  }
+
+  finalize(extra = {}) {
+    const final = {
+      run_id: this.runId,
+      mode: this.mode,
+      finished_at: new Date().toISOString(),
+      metrics: this.metrics,
+      issue_count: this.issues.length,
+      issues: this.issues,
+      ...extra,
+    };
+    this.writeJson("run-summary.json", final);
+    if (!existsSync(join(this.runDir, "report.md"))) {
+      this.writeText("report.md", "# Istara Real User Benchmark Report\n\nNo narrative was written before finalize.\n");
+    }
+    return final;
+  }
+}

--- a/tests/real_user_benchmark/lib/persona.mjs
+++ b/tests/real_user_benchmark/lib/persona.mjs
@@ -1,0 +1,136 @@
+export function buildChatTurns({ total = 108 } = {}) {
+  const seedTurns = [
+    "I am starting a new project called CareNav Renewal. Before you analyze anything, ask me the minimum clarifying questions you need as my research partner.",
+    "Here is the context: we are redesigning appointment-prep coordination for care coordinators, patients, and caregivers. Summarize what you think the project is and flag assumptions.",
+    "I am uploading a previous research archive. When it is ready, tell me what kinds of sources you found and what might be risky to synthesize.",
+    "Please search across the uploaded interviews for evidence about trust in readiness statuses. Cite source names when you can.",
+    "Use RAG/search intentionally here: tell me which retrieved sources actually changed the answer and which were noise.",
+    "That is too generic. Separate staff evidence from patient/caregiver evidence and call out contradictions.",
+    "Create tasks to analyze interview pain points, survey trends, diary-study friction, and support-ticket themes. Keep them reviewable.",
+    "Call whichever Istara skills or tools are appropriate for this corpus, but tell me what you attempted and what returned useful evidence.",
+    "What does the survey say about reminder clarity by role and language? Do not overclaim if the CSV is thin.",
+    "Pull together early atomic findings as nuggets, facts, insights, and recommendations if the evidence supports them.",
+    "Check whether any memento, memory, or reasoning-bank style context exists for this project and whether it should influence the next steps.",
+    "Use the usability reports to compare prototype A and prototype B. I care about scan speed and source-trail trust.",
+    "I want a report outline for leadership, but make it evidence-led, not a marketing narrative.",
+    "Before drafting the report, reason through the evidence chain and mark any claim that needs another retrieval pass.",
+    "Try fetching the NN/g service blueprinting URL from the project URL list and tell me whether it is relevant to this workflow.",
+    "Create a task to evaluate caregiver permission language. Include the Portuguese and Spanish examples as context.",
+    "I suspect you are mixing caregiver and coordinator needs. Please correct that and state which sources changed your mind.",
+    "Create a small agent or specialist workflow if Istara supports it, then evaluate whether the handoff made the answer better.",
+    "Draft a research-backed design brief for a readiness timeline screen.",
+    "Now generate or request an interface concept for the readiness timeline using the available design tools.",
+    "If hyperagent or governed-improvement features exist, use the safest test path to suggest one benchmark-process improvement and keep it reviewable.",
+    "Open the integrations thinking: what would I need to test Telegram recruitment without a real bot token?",
+    "Try a fake Telegram setup path and tell me whether the errors are useful for a researcher.",
+    "Create an AURA-style deployment plan for five adaptive interview questions about appointment preparation.",
+    "Simulate participant responses if the app has a local harness. If not, record exactly what is missing.",
+    "Try Typeform survey creation or a developer/demo path. I do not have credentials.",
+    "Try SurveyMonkey sync with a demo/fake provider setup. Classify the result honestly.",
+    "Try Google Forms setup. If service account JSON is required, test validation behavior without exposing secrets.",
+    "Try Figma import with a fake URL and the mock design path if one exists.",
+    "Try Google Stitch or the mock screen generation flow and show me what was generated.",
+    "Check ensemble, MoA, or compute-health surfaces. I want to know whether donated Gemma chat is healthy before I trust the synthesis.",
+    "Set up a loop or schedule that would recheck new support tickets weekly.",
+    "Check Autoresearch status and explain whether it can be tested safely in this credential-free run.",
+    "Try an autoresearch or research-agent path that uses tools, but keep it bounded to this project and tell me if it refuses safely.",
+    "Review the tasks currently in Review. Approve only work that is specific, grounded, and useful.",
+    "For weak reviewed work, send it back with concrete instructions instead of marking it done.",
+    "Give me a compact decision log: what should the team design first and why?",
+    "Now challenge your own conclusion. What evidence could point the other way?",
+  ];
+
+  const followUps = [
+    "Please cite the exact files you relied on for that statement.",
+    "Turn that into a task with a clear review checklist.",
+    "This feels vague. Rewrite it as a finding with source, evidence, implication, and confidence.",
+    "What would you ask in the next participant interview to reduce uncertainty?",
+    "Compare patient versus staff needs in a two-column summary.",
+    "What should we not automate yet because trust is too low?",
+    "Use the analytics export to sanity-check whether the qualitative pattern appears in behavior.",
+    "Which recommendation has the strongest evidence and which is only a hypothesis?",
+    "Ask Istara to use the reasoning bank or project memory, then verify whether the response cites current corpus evidence too.",
+    "Ask for a tool-call or skill-call trace if available; otherwise record that observability gap.",
+    "Stress the context window: summarize only the newest contradictory evidence without losing the original project constraints.",
+    "Create a small survey question set to validate this with caregivers.",
+    "What UI state should exist for stale or contradictory readiness evidence?",
+    "Find any multilingual wording risk in the archive.",
+    "What is the smallest prototype we could test next week?",
+    "Turn the strongest insight into a design principle.",
+    "Write a task for generating an executive readout slide.",
+    "Review whether the source trail concept could create privacy risk.",
+    "Use web context only if it adds something concrete.",
+    "Check if any task is stuck in Review and needs human approval.",
+    "If the result is unsupported, ask yourself what context was missing.",
+  ];
+
+  const turns = [...seedTurns];
+  let i = 0;
+  while (turns.length < total) {
+    turns.push(followUps[i % followUps.length]);
+    i += 1;
+  }
+  return turns.slice(0, total).map((content, index) => ({
+    turn: index + 1,
+    speaker: "Maya Rodrigues",
+    content,
+    intent: index < seedTurns.length ? "scenario-steering" : "natural-follow-up",
+  }));
+}
+
+export function buildTaskPlan({ total = 60 } = {}) {
+  const taskTypes = [
+    ["Analyze staff interview trust signals", "Extract staff evidence about readiness-status trust, source trails, and manual overrides."],
+    ["Analyze patient appointment-prep blockers", "Identify patient-facing blockers, especially required versus optional tasks."],
+    ["Analyze caregiver permission confusion", "Synthesize caregiver evidence, multilingual examples, and support tickets about access boundaries."],
+    ["Survey trend readout", "Quantify reminder clarity, readiness trust, NPS, and role/language differences from the survey CSV."],
+    ["Usability prototype comparison", "Compare prototype A and B for scan speed, source-trail comprehension, and caregiver-safe update completion."],
+    ["Diary study synthesis", "Find recurring day-by-day prep friction and emotional patterns."],
+    ["Support ticket theme clustering", "Cluster support tickets into actionable product themes and severity patterns."],
+    ["Design brief for readiness timeline", "Create a brief grounded in findings, with UI requirements and non-goals."],
+    ["Interface generation review", "Evaluate generated readiness timeline screens for evidence fit and usability risks."],
+    ["Integration setup audit", "Document credential-free setup, harness status, and graceful degradation for one integration."],
+    ["RAG grounding audit", "Inspect retrieved evidence quality, source precision, false positives, and missing-source risks for one chat synthesis."],
+    ["Tool and skill trace audit", "Check whether Istara exposed useful tool-call or skill-call evidence for a researcher-facing answer."],
+    ["ReasoningBank and memento audit", "Evaluate whether project memory, reasoning bank, or memento-style context improves or contaminates the answer."],
+    ["Hyperagent workflow audit", "Use the safest available hyperagent or governed-improvement path and review whether it produced a bounded useful improvement."],
+    ["Compute and ensemble health audit", "Verify donated compute health, model routing, and any ensemble/MoA health evidence before relying on synthesis."],
+  ];
+  const tasks = [];
+  for (let i = 0; i < total; i += 1) {
+    const [title, description] = taskTypes[i % taskTypes.length];
+    tasks.push({
+      title: `[RU-${String(i + 1).padStart(2, "0")}] ${title}`,
+      description,
+      skill_name: i % 5 === 0 ? "analyze-interview" : "",
+      priority: i % 9 === 0 ? "high" : "medium",
+      labels: ["real-user-benchmark", i % 7 === 0 ? "needs-citations" : "synthesis"],
+      shouldReviseFirst: i % 8 === 0,
+      acceptance: [
+        "Names at least two source documents when evidence is synthesized.",
+        "Distinguishes evidence, interpretation, and recommendation.",
+        "States confidence or uncertainty.",
+        "Avoids medical advice and private patient disclosure.",
+      ],
+    });
+  }
+  return tasks;
+}
+
+export function reviewerAssessment(task, agentNotes) {
+  const notes = String(agentNotes || "");
+  const issues = [];
+  if (notes.length < 80) issues.push("output is too brief");
+  if (!/source|interview|survey|usability|ticket|diary/i.test(notes)) issues.push("missing source references");
+  if (!/confidence|uncertain|evidence|because/i.test(notes)) issues.push("missing confidence or evidence reasoning");
+  if (/medical advice|diagnose|treatment plan/i.test(notes)) issues.push("unsafe medical inference");
+  const approved = issues.length === 0;
+  return {
+    approved,
+    issues,
+    score: Math.max(0, 1 - issues.length * 0.25),
+    revisionInstruction: issues.length
+      ? `Please revise ${task.title}: ${issues.join("; ")}. Add source names, separate evidence from interpretation, and state confidence.`
+      : `Approved: output is specific, grounded, and reviewable for ${task.title}.`,
+  };
+}

--- a/tests/real_user_benchmark/lib/playwright-ui.mjs
+++ b/tests/real_user_benchmark/lib/playwright-ui.mjs
@@ -1,0 +1,474 @@
+import { join } from "path";
+
+const CHAT_INPUT_SELECTORS = [
+  "textarea[placeholder*='Ask about your research']",
+  "textarea[placeholder*='Viewer access is read-only']",
+];
+
+async function screenshot(page, logger, name) {
+  const path = join(logger.paths.screenshots, `${String(logger.metrics.screenshots + 1).padStart(3, "0")}-${name}.png`);
+  await page.screenshot({ path, fullPage: true }).catch(() => {});
+  logger.noteScreenshot();
+  logger.action("ui.screenshot", { name, path });
+  return path;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function isVisible(page, selector, timeout = 250) {
+  try {
+    return await page.locator(selector).first().isVisible({ timeout });
+  } catch {
+    return false;
+  }
+}
+
+async function bodyText(page) {
+  try {
+    return (await page.locator("body").innerText({ timeout: 1000 })).replace(/\s+/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
+async function clickByText(page, text) {
+  const exact = new RegExp(`^${escapeRegExp(text)}$`, "i");
+  const loose = new RegExp(escapeRegExp(text), "i");
+  const locators = [
+    page.getByRole("tab", { name: loose }),
+    page.getByRole("button", { name: loose }),
+    page.getByRole("link", { name: loose }),
+    page.getByText(exact),
+    page.getByText(loose),
+  ];
+  for (const locator of locators) {
+    try {
+      if (await locator.first().isVisible({ timeout: 1500 })) {
+        await locator.first().click({ timeout: 5000 });
+        return true;
+      }
+    } catch {}
+  }
+  return false;
+}
+
+async function installNetworkTokenRoute(page, api, logger) {
+  const token = api?.networkAccessToken || "";
+  const apiBase = api?.apiBase || "";
+  if (!token || !apiBase) return;
+  const basePattern = new RegExp(`^${escapeRegExp(apiBase.replace(/\/$/, ""))}/`);
+  await page.route(basePattern, async (route) => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        "X-Access-Token": token,
+      },
+    });
+  });
+  logger.action("ui.network_token_route.installed", { actor_token_configured: true });
+}
+
+const NAV_VIEW_IDS = new Map([
+  ["Chat", "chat"],
+  ["Documents", "documents"],
+  ["Tasks", "tasks"],
+  ["Findings", "findings"],
+  ["Integrations", "integrations"],
+  ["Interfaces", "interfaces"],
+  ["Loops", "loops"],
+  ["Autoresearch", "autoresearch"],
+  ["Settings", "settings"],
+]);
+
+async function clickLocator(locator, method) {
+  try {
+    if ((await locator.count()) === 0) return null;
+    const target = locator.first();
+    await target.scrollIntoViewIfNeeded({ timeout: 1500 }).catch(() => {});
+    if (await target.isVisible({ timeout: 1500 })) {
+      await target.click({ timeout: 5000 });
+      return { clicked: true, method };
+    }
+    await target.click({ timeout: 5000, force: true });
+    return { clicked: true, method: `${method}:force` };
+  } catch {
+    return null;
+  }
+}
+
+async function clickNavigationItem(page, text) {
+  const exact = new RegExp(`^${escapeRegExp(text)}$`, "i");
+  const sidebar = page.locator("aside[role='navigation']").first();
+  const clickTab = async () => {
+    const tabResult = await clickLocator(sidebar.getByRole("tab", { name: exact }), "sidebar-tab");
+    if (tabResult) return tabResult;
+    const buttonResult = await clickLocator(sidebar.getByRole("button", { name: exact }), "sidebar-button");
+    if (buttonResult) return buttonResult;
+    return await clickLocator(sidebar.locator("button").filter({ hasText: exact }), "sidebar-text");
+  };
+
+  const firstAttempt = await clickTab();
+  if (firstAttempt) return firstAttempt;
+  try {
+    const more = sidebar.getByRole("button", { name: /More views|More/i }).first();
+    if (await more.isVisible({ timeout: 1000 })) {
+      await more.click({ timeout: 3000 });
+      await page.waitForTimeout(250);
+    }
+  } catch {}
+  const expandedAttempt = await clickTab();
+  if (expandedAttempt) return expandedAttempt;
+
+  const domAttempt = await page.evaluate((label) => {
+    const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim().toLowerCase();
+    const aside = document.querySelector("aside[role='navigation']");
+    if (!aside) return { clicked: false, reason: "no-sidebar" };
+    const candidates = Array.from(aside.querySelectorAll("button, [role='tab'], a"));
+    const target = candidates.find((element) => {
+      const accessible = element.getAttribute("aria-label") || element.getAttribute("title") || element.textContent;
+      return normalize(accessible) === normalize(label);
+    });
+    if (!target) {
+      return {
+        clicked: false,
+        reason: "target-not-found",
+        candidates: candidates.map((element) => element.getAttribute("aria-label") || element.textContent || "").slice(0, 30),
+      };
+    }
+    target.scrollIntoView({ block: "center", inline: "nearest" });
+    target.click();
+    return { clicked: true, label: target.getAttribute("aria-label") || target.textContent || "" };
+  }, text);
+  if (domAttempt.clicked) return { clicked: true, method: "dom-sidebar-click", detail: domAttempt };
+
+  const view = NAV_VIEW_IDS.get(text);
+  if (view) {
+    await page.evaluate((viewId) => {
+      localStorage.setItem("istara_active_view", viewId);
+      window.dispatchEvent(new CustomEvent("istara:navigate", { detail: { view: viewId } }));
+    }, view);
+    return { clicked: true, method: "istara-navigate-event", detail: domAttempt };
+  }
+
+  return { clicked: false, method: "not-found", detail: domAttempt };
+}
+
+async function fillFirst(page, selectors, value) {
+  for (const selector of selectors) {
+    const locator = page.locator(selector).first();
+    try {
+      if (await locator.isVisible({ timeout: 1000 })) {
+        await locator.fill(value);
+        return true;
+      }
+    } catch {}
+  }
+  return false;
+}
+
+async function classifyUiState(page) {
+  const text = await bodyText(page);
+  const chatInputVisible = (await Promise.all(
+    CHAT_INPUT_SELECTORS.map((selector) => isVisible(page, selector, 150)),
+  )).some(Boolean);
+  const navigationVisible = await isVisible(page, "aside[role='navigation']", 150);
+  const mainVisible = await isVisible(page, "main#main-content", 150);
+  const authFormVisible = (
+    await isVisible(page, "#login-username, input[aria-label='Username'], textarea#join-connection-string", 150)
+  );
+  const loginVisible = !navigationVisible && (
+    authFormVisible || /Sign In|Create Admin Account|Join Server/i.test(text)
+  );
+  const connecting = /Connecting to Istara/i.test(text);
+  const serverUnreachable = /Cannot connect to the Istara server/i.test(text);
+  const onboardingVisible = /Create your first project|Initial Setup|Save your recovery codes|Add a passkey/i.test(text);
+  const noProject = /No Project Selected/i.test(text);
+  const errorBoundary = /Something went wrong|Try again|Error/i.test(text) && mainVisible;
+
+  let state = "unknown";
+  if (!text && !mainVisible && !navigationVisible) state = "blank";
+  else if (serverUnreachable) state = "server_unreachable";
+  else if (connecting) state = "connecting";
+  else if (chatInputVisible) state = "chat";
+  else if (loginVisible) state = "login";
+  else if (onboardingVisible) state = "onboarding";
+  else if (noProject) state = "no_project";
+  else if (navigationVisible && mainVisible) state = "shell";
+  else if (errorBoundary) state = "error";
+
+  return {
+    state,
+    url: page.url(),
+    chatInputVisible,
+    navigationVisible,
+    mainVisible,
+    textPreview: text.slice(0, 500),
+  };
+}
+
+async function waitForUiState(page, logger, label, {
+  timeoutMs = 45000,
+  accepted = ["login", "chat", "shell", "no_project", "onboarding", "server_unreachable"],
+} = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let last = await classifyUiState(page);
+  while (Date.now() < deadline) {
+    last = await classifyUiState(page);
+    if (accepted.includes(last.state)) {
+      logger.action("ui.state.ready", { label, ...last });
+      return last;
+    }
+    await page.waitForTimeout(500);
+  }
+  logger.action("ui.state.timeout", { label, ...last });
+  return last;
+}
+
+async function installBenchmarkSession(page, { api, projectId }) {
+  if (!api.token) return;
+  await page.evaluate(({ token, userId, projectId: activeProjectId }) => {
+    const uid = userId || "benchmark-admin";
+    localStorage.setItem("istara_token", token);
+    localStorage.setItem("istara_auth_user_id", uid);
+    localStorage.setItem("istara-active-project", activeProjectId);
+    localStorage.setItem("istara_active_view", "chat");
+    localStorage.setItem(`istara_tour_completed_${uid}`, "true");
+    localStorage.setItem("istara_tour_completed_anonymous", "true");
+    localStorage.setItem("istara_tour_state", JSON.stringify({ active: false, isOnboarding: false, step: 0 }));
+    window.dispatchEvent(new Event("istara:auth-changed"));
+  }, { token: api.token, userId: api.userId, projectId });
+}
+
+async function performCredentialLogin(page, logger, credentials) {
+  if (!credentials?.username || !credentials?.password) return false;
+  const state = await classifyUiState(page);
+  if (state.state !== "login") return false;
+
+  const registering = /Create Admin Account/i.test(state.textPreview);
+  logger.action("ui.auth.form_detected", { registering, state: state.state });
+
+  try {
+    await page.getByLabel("Username").fill(credentials.username, { timeout: 5000 });
+    await page.getByLabel("Password").fill(credentials.password, { timeout: 5000 });
+    if (registering) {
+      const email = `${credentials.username}@benchmark.istara.local`;
+      await page.getByLabel("Email").fill(email, { timeout: 5000 });
+    }
+    await page.getByRole("button", { name: registering ? /^Create Admin Account$/i : /^Sign In$/i }).click({ timeout: 5000 });
+    await page.waitForTimeout(1000);
+    const afterSubmit = await waitForUiState(page, logger, "after-ui-auth", {
+      timeoutMs: 45000,
+      accepted: ["chat", "shell", "onboarding", "no_project", "login", "server_unreachable"],
+    });
+    const ok = !["login", "server_unreachable", "blank", "connecting"].includes(afterSubmit.state);
+    logger.action("ui.auth.result", { ok, ...afterSubmit });
+    return ok;
+  } catch (error) {
+    logger.action("ui.auth.error", { error: error.message, state });
+    return false;
+  }
+}
+
+async function captureDiagnostics(page, logger, title, detail, severity = "medium") {
+  const state = await classifyUiState(page);
+  await screenshot(page, logger, `diagnostic-${title}`.replace(/[^a-z0-9_-]+/gi, "-").toLowerCase());
+  logger.action("ui.diagnostic", { title, detail, ...state });
+  logger.issue({
+    area: "ui",
+    severity,
+    title,
+    detail: `${detail} Current UI state: ${state.state}. Body preview: ${state.textPreview}`,
+  });
+  return state;
+}
+
+function attachPageDiagnostics(page, logger) {
+  const counters = { console: 0, pageerror: 0, requestfailed: 0, http: 0 };
+  page.on("console", (message) => {
+    if (counters.console >= 80) return;
+    counters.console += 1;
+    const type = message.type();
+    if (["error", "warning"].includes(type)) {
+      logger.action("ui.console", { type, text: message.text().slice(0, 1000) });
+    }
+  });
+  page.on("pageerror", (error) => {
+    if (counters.pageerror >= 40) return;
+    counters.pageerror += 1;
+    logger.action("ui.pageerror", { error: error.message.slice(0, 1000) });
+  });
+  page.on("requestfailed", (request) => {
+    if (counters.requestfailed >= 80) return;
+    counters.requestfailed += 1;
+    logger.action("ui.requestfailed", {
+      method: request.method(),
+      url: request.url(),
+      failure: request.failure()?.errorText || "",
+    });
+  });
+  page.on("response", (response) => {
+    if (counters.http >= 80 || response.status() < 400) return;
+    counters.http += 1;
+    logger.action("ui.http_error", {
+      status: response.status(),
+      url: response.url(),
+    });
+  });
+}
+
+export async function runUiJourney({ frontendUrl, api, projectId, logger, chatTurns = [], credentials = null, actor = "admin" }) {
+  let chromium;
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch {
+    ({ chromium } = await import("../../simulation/node_modules/playwright/index.mjs"));
+  }
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 920 },
+    recordVideo: undefined,
+  });
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: false }).catch(() => {});
+  const page = await context.newPage();
+  attachPageDiagnostics(page, logger);
+  const results = {
+    visited: false,
+    onboarding: false,
+    chatUiTurns: 0,
+    uploadAttempted: false,
+    nav: [],
+    finalState: "",
+  };
+
+  try {
+    logger.action("ui.journey.start", { actor });
+    await installNetworkTokenRoute(page, api, logger);
+    await page.goto(frontendUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
+    await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+    results.visited = true;
+    await screenshot(page, logger, "landing");
+
+    let state = await waitForUiState(page, logger, "landing");
+    if (state.state === "login") {
+      const loggedIn = await performCredentialLogin(page, logger, credentials);
+      if (loggedIn) await screenshot(page, logger, "ui-login-complete");
+      state = await classifyUiState(page);
+    }
+
+    if (api.token && projectId && ["chat", "shell", "no_project", "onboarding"].includes(state.state)) {
+      logger.action("ui.session.align", {
+        reason: state.state,
+        note: "Completing benchmark tour state and selecting the generated project after real UI authentication.",
+      });
+      await installBenchmarkSession(page, { api, projectId });
+      await page.reload({ waitUntil: "domcontentloaded", timeout: 60000 });
+      await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+      await screenshot(page, logger, "authenticated-chat-ready");
+      state = await waitForUiState(page, logger, "after-session-align", {
+        accepted: ["chat", "shell", "no_project", "onboarding", "server_unreachable"],
+      });
+    }
+
+    if (api.token && ["login", "blank", "connecting", "server_unreachable", "onboarding", "no_project"].includes(state.state)) {
+      logger.action("ui.session.install", {
+        reason: state.state,
+        note: "Installing known benchmark session after observing current app state.",
+      });
+      await installBenchmarkSession(page, { api, projectId });
+      await page.reload({ waitUntil: "domcontentloaded", timeout: 60000 });
+      await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+      await screenshot(page, logger, "authenticated-home");
+      state = await waitForUiState(page, logger, "after-session-install", {
+        accepted: ["chat", "shell", "no_project", "onboarding", "server_unreachable"],
+      });
+    }
+
+    results.onboarding = ["chat", "shell", "no_project"].includes(state.state);
+    if (!["chat", "shell", "no_project"].includes(state.state)) {
+      results.finalState = state.state;
+      await captureDiagnostics(page, logger, "Playwright UI shell was not ready", "The benchmark did not navigate because the app shell was not in a usable state.", "high");
+      return results;
+    }
+
+    for (const nav of ["Chat", "Documents", "Tasks", "Findings", "Integrations", "Interfaces", "Loops", "Autoresearch", "Settings"]) {
+      const beforeNav = await waitForUiState(page, logger, `before-nav-${nav}`, {
+        timeoutMs: 15000,
+        accepted: ["chat", "shell", "no_project"],
+      });
+      if (!["chat", "shell", "no_project"].includes(beforeNav.state)) {
+        results.nav.push({ nav, clicked: false, reason: beforeNav.state });
+        logger.action("ui.nav.skip", { nav, reason: beforeNav.state });
+        continue;
+      }
+      const navResult = await clickNavigationItem(page, nav);
+      results.nav.push({ nav, ...navResult });
+      logger.action("ui.nav", { nav, ...navResult });
+      if (navResult.clicked) {
+        await page.waitForTimeout(700);
+        await screenshot(page, logger, `nav-${nav.toLowerCase()}`);
+      }
+    }
+
+    const chatNavResult = await clickNavigationItem(page, "Chat");
+    logger.action("ui.nav.return_to_chat", chatNavResult);
+    await waitForUiState(page, logger, "chat-before-turns", {
+      timeoutMs: 20000,
+      accepted: ["chat", "shell", "no_project"],
+    });
+    for (const turn of chatTurns.slice(0, 5)) {
+      let filled = await fillFirst(page, CHAT_INPUT_SELECTORS, turn.content);
+      if (!filled) {
+        const chatState = await classifyUiState(page);
+        logger.action("ui.chat_input.retry", { turn: turn.turn, ...chatState });
+        if (api.token) {
+          await installBenchmarkSession(page, { api, projectId });
+          const retryNavResult = await clickNavigationItem(page, "Chat");
+          logger.action("ui.nav.retry_chat", retryNavResult);
+          await page.waitForTimeout(750);
+          filled = await fillFirst(page, CHAT_INPUT_SELECTORS, turn.content);
+        }
+      }
+      if (!filled) {
+        await captureDiagnostics(
+          page,
+          logger,
+          "Chat composer unavailable after UI readiness checks",
+          "Playwright waited for render, verified the app state, retried session/project selection, and still could not locate a usable Chat composer.",
+          "high",
+        );
+        break;
+      }
+      const sent = await clickByText(page, "Send message") || await clickByText(page, "Send");
+      if (!sent) {
+        await page.keyboard.press("Meta+Enter").catch(() => {});
+        await page.keyboard.press("Enter").catch(() => {});
+      }
+      results.chatUiTurns += 1;
+      await page.waitForTimeout(1200);
+      await screenshot(page, logger, `chat-turn-${turn.turn}`.replace(/\s+/g, "-"));
+    }
+
+    try {
+      results.uploadAttempted = (await page.locator("input[type=file]").count()) > 0;
+    } catch {
+      results.uploadAttempted = false;
+    }
+    logger.action("ui.chat_upload_probe", { upload_input_present: results.uploadAttempted });
+    const finalState = await classifyUiState(page);
+    results.finalState = finalState.state;
+    logger.action("ui.final_state", finalState);
+  } catch (error) {
+    logger.issue({
+      area: "ui",
+      severity: "high",
+      title: "Playwright UI journey failed",
+      detail: error.message,
+    });
+  } finally {
+    await context.tracing.stop({ path: join(logger.paths.traces, `ui-journey-${actor}-trace.zip`) }).catch(() => {});
+    await browser.close().catch(() => {});
+  }
+  return results;
+}

--- a/tests/real_user_benchmark/lib/scoring.mjs
+++ b/tests/real_user_benchmark/lib/scoring.mjs
@@ -1,0 +1,99 @@
+const RUBRIC = [
+  ["install", 10],
+  ["onboarding", 8],
+  ["corpus", 10],
+  ["chat", 10],
+  ["grounding", 10],
+  ["tasks", 12],
+  ["reports_findings", 10],
+  ["integrations", 10],
+  ["loops_autoresearch", 6],
+  ["url_fetching", 4],
+  ["interfaces", 4],
+  ["stability_performance", 4],
+  ["researcher_usefulness", 2],
+];
+
+export function scoreRun({ mode, metrics, integrationMatrix = [], blockers = [], completedTasks = 0, chatTurns = 0, uploadedDocuments = 0, sandbox = {}, featureResults = {} }) {
+  const integrationScores = integrationMatrix.map((item) => {
+    switch (item.classification) {
+      case "live-tested": return 1;
+      case "developer-harness-tested": return 0.85;
+      case "setup-error-path-tested": return 0.55;
+      case "blocked-no-test-harness": return 0.25;
+      case "not-implemented": return 0;
+      default: return 0.2;
+    }
+  });
+  const avgIntegration = integrationScores.length
+    ? integrationScores.reduce((sum, item) => sum + item, 0) / integrationScores.length
+    : 0;
+
+  const raw = {
+    install: sandbox.serverStarted ? 1 : sandbox.serverAttempted ? 0.45 : mode === "plan-only" ? 0.2 : 0.3,
+    onboarding: featureResults.uiOnboarding ? 1 : featureResults.uiVisited ? 0.55 : 0.2,
+    corpus: uploadedDocuments >= 20 ? 1 : uploadedDocuments > 0 ? 0.6 : metrics?.corpusDocuments >= 20 ? 0.4 : 0.2,
+    chat: chatTurns >= 100 ? 1 : chatTurns >= 8 ? 0.45 : chatTurns > 0 ? 0.25 : 0.1,
+    grounding: featureResults.citedSources ? 1 : featureResults.uploadedAndQueried ? 0.55 : 0.25,
+    tasks: completedTasks >= 50 ? 1 : completedTasks >= 8 ? 0.45 : completedTasks > 0 ? 0.25 : 0.1,
+    reports_findings: featureResults.findingsCreated || featureResults.reportGenerated ? 0.75 : 0.25,
+    integrations: avgIntegration,
+    loops_autoresearch: featureResults.loops ? 0.65 : 0.2,
+    url_fetching: featureResults.urlFetch ? 0.7 : 0.2,
+    interfaces: featureResults.interfaces ? 0.85 : 0.2,
+    stability_performance: blockers.length === 0 ? 0.85 : blockers.length < 4 ? 0.55 : 0.25,
+    researcher_usefulness: completedTasks >= 50 && chatTurns >= 100 ? 0.9 : 0.35,
+  };
+
+  const dimensions = RUBRIC.map(([key, weight]) => ({
+    key,
+    weight,
+    score: Math.round(raw[key] * weight * 100) / 100,
+    max: weight,
+    ratio: raw[key],
+  }));
+  const total = Math.round(dimensions.reduce((sum, dim) => sum + dim.score, 0) * 10) / 10;
+  return {
+    total,
+    max: 100,
+    mode,
+    completed_tasks: completedTasks,
+    chat_turns: chatTurns,
+    uploaded_documents: uploadedDocuments,
+    compute_donation_verified: Boolean(featureResults.computeDonation),
+    live_chat_verified: Boolean(featureResults.liveChat),
+    dimensions,
+    blockers,
+    integration_summary: integrationMatrix.map((item) => ({
+      integration: item.integration,
+      classification: item.classification,
+    })),
+  };
+}
+
+export function writeScorecardMarkdown(scorecard) {
+  const lines = [
+    "## Scorecard",
+    "",
+    `Overall score: ${scorecard.total}/100`,
+    "",
+    "| Dimension | Score | Max |",
+    "| --- | ---: | ---: |",
+  ];
+  for (const dim of scorecard.dimensions) {
+    lines.push(`| ${dim.key} | ${dim.score} | ${dim.max} |`);
+  }
+  if (scorecard.blockers.length) {
+    lines.push("", "## Blockers", "");
+    for (const blocker of scorecard.blockers) {
+      lines.push(`- ${blocker}`);
+    }
+  }
+  if (scorecard.integration_summary.length) {
+    lines.push("", "## Integration Classifications", "");
+    for (const item of scorecard.integration_summary) {
+      lines.push(`- ${item.integration}: ${item.classification}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/tests/real_user_benchmark/package.json
+++ b/tests/real_user_benchmark/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "istara-real-user-benchmark",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "plan": "node run.mjs --mode plan-only",
+    "probe": "node run.mjs --mode probe --max-chat-turns 8 --max-tasks 8",
+    "full": "node run.mjs --mode full --start-sandbox",
+    "check": "node --check run.mjs && node --check lib/api-client.mjs && node --check lib/corpus.mjs && node --check lib/integration-discovery.mjs && node --check lib/logger.mjs && node --check lib/persona.mjs && node --check lib/playwright-ui.mjs && node --check lib/scoring.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.59.1"
+  }
+}

--- a/tests/real_user_benchmark/run.mjs
+++ b/tests/real_user_benchmark/run.mjs
@@ -1,0 +1,3100 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "fs";
+import { createHash, randomBytes } from "crypto";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { spawnSync } from "child_process";
+import { createInterface } from "readline/promises";
+
+import { IstaraApiClient } from "./lib/api-client.mjs";
+import { generateCorpus, PROJECT_CONTEXT } from "./lib/corpus.mjs";
+import { runIntegrationMatrix } from "./lib/integration-discovery.mjs";
+import { BenchmarkLogger, makeRunId } from "./lib/logger.mjs";
+import { buildChatTurns, buildTaskPlan, reviewerAssessment } from "./lib/persona.mjs";
+import { runUiJourney } from "./lib/playwright-ui.mjs";
+import { scoreRun, writeScorecardMarkdown } from "./lib/scoring.mjs";
+import { inferProviderType } from "../../relay/lib/llm-proxy.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+const systemPromptPath = join(__dirname, "system-prompt.md");
+const benchmarkRegistryPath = join(__dirname, "benchmark-registry.json");
+const systemPromptContent = readFileSync(systemPromptPath, "utf8");
+const benchmarkRegistry = JSON.parse(readFileSync(benchmarkRegistryPath, "utf8"));
+const systemPromptHash = createHash("sha256").update(systemPromptContent).digest("hex");
+const systemPromptVersion = systemPromptContent.match(/^Version:\s*(.+)$/m)?.[1]?.trim() || "unknown";
+const LIVE_LLM_ENV_FILES = [
+  join(repoRoot, ".env"),
+  join(repoRoot, ".env.local"),
+  join(repoRoot, "backend", ".env"),
+  join(repoRoot, "backend", ".env.local"),
+];
+const LIVE_LLM_ENV_KEYS = new Set([
+  "ISTARA_LIVE_LLM_BASE_URL",
+  "ISTARA_PRIMARY_LLM_TEST_BASE_URL",
+  "LMSTUDIO_HOST",
+  "ISTARA_LIVE_LLM_API_KEY",
+  "ISTARA_LLM_TEST_API_KEY",
+  "ISTARA_PRIMARY_LLM_TEST_API_KEY",
+  "LMSTUDIO_API_KEY",
+  "ISTARA_LIVE_LLM_KEYCHAIN_SERVICE",
+]);
+const LIVE_LLM_BASE_URL_KEYS = [
+  "ISTARA_LIVE_LLM_BASE_URL",
+  "ISTARA_PRIMARY_LLM_TEST_BASE_URL",
+  "LMSTUDIO_HOST",
+];
+const LIVE_LLM_API_KEY_KEYS = [
+  "ISTARA_LIVE_LLM_API_KEY",
+  "ISTARA_LLM_TEST_API_KEY",
+  "ISTARA_PRIMARY_LLM_TEST_API_KEY",
+  "LMSTUDIO_API_KEY",
+];
+const PRIMARY_TEST_MODEL = "google/gemma-4-e4b";
+const FUTURE_QWEN_DONOR_MODEL = "Qwen3.5-4B";
+const DEFAULT_LIVE_LLM_KEYCHAIN_SERVICE = "istara-live-openai-compatible-tests";
+const startupConfigWarnings = [];
+
+function arg(name, fallback = null) {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index >= 0) return process.argv[index + 1] || "true";
+  return fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+function intArg(name, fallback) {
+  const value = arg(name, process.env[`ISTARA_BENCHMARK_${name.toUpperCase().replace(/-/g, "_")}`]);
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function floatEnv(name, fallback) {
+  const parsed = Number.parseFloat(process.env[name]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function boolEnv(name, fallback = false) {
+  const value = process.env[name];
+  if (value === undefined || value === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function parseEnvAssignment(rawLine, allowedKeys = null) {
+  let line = rawLine.trim();
+  if (!line || line.startsWith("#") || !line.includes("=")) return null;
+  if (line.startsWith("export ")) line = line.slice("export ".length).trim();
+  const index = line.indexOf("=");
+  const key = line.slice(0, index).trim();
+  if (allowedKeys && !allowedKeys.has(key)) return null;
+  let value = line.slice(index + 1).trim();
+  if (value.length >= 2 && value[0] === value[value.length - 1] && ["'", "\""].includes(value[0])) {
+    value = value.slice(1, -1);
+  }
+  return [key, value];
+}
+
+function loadBackendEnv() {
+  const files = [
+    join(repoRoot, "backend", ".env"),
+    join(repoRoot, "backend", ".env.local"),
+  ];
+  const values = {};
+  const sources = {};
+  for (const file of files) {
+    try {
+      const content = readFileSync(file, "utf8");
+      for (const line of content.split(/\r?\n/)) {
+        const parsed = parseEnvAssignment(line);
+        if (!parsed) continue;
+        const [key, value] = parsed;
+        values[key] = value;
+        sources[key] = file.replace(`${repoRoot}/`, "");
+      }
+    } catch {}
+  }
+  values.__sources = sources;
+  return values;
+}
+
+function configuredValue(config, key, fallback = "") {
+  return (process.env[key] ?? config[key] ?? fallback ?? "").trim();
+}
+
+function loadLiveLlmEnv() {
+  const values = {};
+  const sources = {};
+  const loadedFiles = [];
+  for (const key of LIVE_LLM_ENV_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+      values[key] = process.env[key] || "";
+      sources[key] = "process-env";
+    }
+  }
+  for (const file of LIVE_LLM_ENV_FILES) {
+    if (!existsSync(file)) continue;
+    let loaded = false;
+    try {
+      const content = readFileSync(file, "utf8");
+      for (const line of content.split(/\r?\n/)) {
+        const parsed = parseEnvAssignment(line, LIVE_LLM_ENV_KEYS);
+        if (!parsed) continue;
+        const [key, value] = parsed;
+        if (!Object.prototype.hasOwnProperty.call(values, key)) {
+          values[key] = value;
+          sources[key] = file.replace(`${repoRoot}/`, "");
+        }
+        loaded = true;
+      }
+    } catch {}
+    if (loaded) loadedFiles.push(file.replace(`${repoRoot}/`, ""));
+  }
+  values.__sources = sources;
+  values.__loadedFiles = loadedFiles;
+  return values;
+}
+
+function pickFirstPresent(config, keys) {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+      return {
+        key,
+        value: String(config[key] || "").trim(),
+        source: config.__sources?.[key] || "configured",
+      };
+    }
+  }
+  return { key: "", value: "", source: "unset" };
+}
+
+function pickFirstNonEmpty(config, keys) {
+  for (const key of keys) {
+    const value = String(config[key] || "").trim();
+    if (value) {
+      return {
+        key,
+        value,
+        source: config.__sources?.[key] || "configured",
+      };
+    }
+  }
+  return { key: "", value: "", source: "unset" };
+}
+
+function readKeychainSecret(service) {
+  if (!existsSync("/usr/bin/security")) return "";
+  try {
+    const result = spawnSync("/usr/bin/security", [
+      "find-generic-password",
+      "-a",
+      process.env.USER || "istara",
+      "-s",
+      service || DEFAULT_LIVE_LLM_KEYCHAIN_SERVICE,
+      "-w",
+    ], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    });
+    return result.status === 0 ? result.stdout.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function liveLlmProfileFromTestingContract() {
+  const env = loadLiveLlmEnv();
+  const base = pickFirstPresent(env, LIVE_LLM_BASE_URL_KEYS);
+  const key = pickFirstNonEmpty(env, LIVE_LLM_API_KEY_KEYS);
+  const keychainService = String(env.ISTARA_LIVE_LLM_KEYCHAIN_SERVICE || DEFAULT_LIVE_LLM_KEYCHAIN_SERVICE).trim();
+  let apiKey = key.value;
+  let apiKeySource = key.source;
+  if (!apiKey) {
+    apiKey = readKeychainSecret(keychainService);
+    apiKeySource = apiKey ? "macos-keychain" : "unset";
+  }
+  return {
+    baseUrl: base.value,
+    baseUrlKey: base.key,
+    baseUrlSource: base.source,
+    apiKey,
+    apiKeySource,
+    keychainServiceConfigured: keychainService !== DEFAULT_LIVE_LLM_KEYCHAIN_SERVICE,
+    keychainServiceSource: env.__sources?.ISTARA_LIVE_LLM_KEYCHAIN_SERVICE || "default",
+    model: PRIMARY_TEST_MODEL,
+    modelSource: "tests/llm_test_config.py:PRIMARY_TEST_MODEL",
+    loadedEnvFiles: env.__loadedFiles || [],
+  };
+}
+
+function replaceLocalhostForContainer(url) {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    if (["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)) {
+      parsed.hostname = "host.docker.internal";
+    }
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return url;
+  }
+}
+
+function stripOpenAIPathForNativeLMStudio(url, provider) {
+  if (provider !== "lmstudio" || !url) return url;
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/\/+$/, "");
+    if (path === "/v1") {
+      parsed.pathname = "";
+      return parsed.toString().replace(/\/$/, "");
+    }
+  } catch {}
+  return url.replace(/\/$/, "");
+}
+
+function hostSummary(url) {
+  try {
+    const parsed = new URL(url);
+    const local = ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
+    return {
+      configured: Boolean(url),
+      scheme: parsed.protocol.replace(":", ""),
+      host_kind: local ? "localhost" : parsed.hostname === "host.docker.internal" ? "docker-host" : "non-localhost",
+      port_set: Boolean(parsed.port),
+      has_path: Boolean(parsed.pathname && parsed.pathname !== "/"),
+    };
+  } catch {
+    return { configured: Boolean(url), parseable: false };
+  }
+}
+
+function parseJsonConfig(raw, source) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    startupConfigWarnings.push({
+      source,
+      error: `Invalid JSON: ${error.message}`,
+    });
+    return null;
+  }
+}
+
+function readJsonConfigFile(filePath, source) {
+  if (!filePath) return null;
+  try {
+    return parseJsonConfig(readFileSync(resolve(filePath), "utf8"), source);
+  } catch (error) {
+    startupConfigWarnings.push({
+      source,
+      error: `Could not read ${filePath}: ${error.message}`,
+    });
+    return null;
+  }
+}
+
+function asArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function parseConnectionStringList(raw) {
+  if (!raw) return [];
+  const trimmed = String(raw).trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    const parsed = parseJsonConfig(trimmed, "connection-string-list");
+    if (Array.isArray(parsed)) return parsed.map(String).map((item) => item.trim()).filter(Boolean);
+    if (parsed && typeof parsed === "object") {
+      return asArray(
+        parsed.connection_strings
+          || parsed.connectionStrings
+          || parsed.compute_donations
+          || parsed.computeDonations
+          || parsed.user_invites
+          || parsed.userInvites,
+      ).map(String).map((item) => item.trim()).filter(Boolean);
+    }
+    return [];
+  }
+  return trimmed.split(/\r?\n|[,|]/).map((item) => item.trim()).filter(Boolean);
+}
+
+function base64UrlEncode(text) {
+  return Buffer.from(text, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeConnectionStringPayloadUnsafe(connectionString) {
+  const value = String(connectionString || "");
+  if (!value.startsWith("rcl_")) return null;
+  const body = value.slice("rcl_".length);
+  const parts = body.split(".");
+  if (parts.length !== 2) return null;
+  try {
+    const padded = parts[0].padEnd(parts[0].length + ((4 - (parts[0].length % 4)) % 4), "=");
+    const payload = JSON.parse(Buffer.from(padded.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8"));
+    return { payload, signature: parts[1] };
+  } catch {
+    return null;
+  }
+}
+
+function rewriteRelayConnectionStringForContainer(connectionString) {
+  const decoded = decodeConnectionStringPayloadUnsafe(connectionString);
+  if (!decoded) return { connectionString, rewritten: false };
+  const payload = { ...decoded.payload };
+  const before = {
+    server_url: payload.server_url || "",
+    ws_url: payload.ws_url || "",
+  };
+  if (payload.server_url) payload.server_url = replaceLocalhostForContainer(payload.server_url);
+  if (payload.ws_url) payload.ws_url = replaceLocalhostForContainer(payload.ws_url);
+  const rewritten = before.server_url !== payload.server_url || before.ws_url !== payload.ws_url;
+  if (!rewritten) return { connectionString, rewritten: false };
+  const payloadB64 = base64UrlEncode(JSON.stringify(payload));
+  return {
+    connectionString: `rcl_${payloadB64}.${decoded.signature}`,
+    rewritten: true,
+    before: {
+      server_url: hostSummary(before.server_url),
+      ws_url: hostSummary(before.ws_url),
+    },
+    after: {
+      server_url: hostSummary(payload.server_url),
+      ws_url: hostSummary(payload.ws_url),
+    },
+    note: "Relay CLI does not verify the connection-string HMAC; rewriting localhost lets a container reach an external host-server while preserving the embedded network token. User invite strings are not rewritten because the server validates their HMAC.",
+  };
+}
+
+function rememberConnectionStringSensitiveValues(connectionString) {
+  const decoded = decodeConnectionStringPayloadUnsafe(connectionString);
+  if (!decoded?.payload) return;
+  for (const value of [
+    decoded.payload.server_url,
+    decoded.payload.ws_url,
+    decoded.payload.network_token,
+    decoded.payload.jwt,
+  ]) {
+    if (typeof value === "string" && value.trim()) extraSensitiveLogValues.add(value.trim());
+  }
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    const stringValue = String(value).trim();
+    if (stringValue) return stringValue;
+  }
+  return "";
+}
+
+function envDonorValue(index, keys) {
+  for (const key of keys) {
+    const value = process.env[`ISTARA_BENCHMARK_DONOR_${index}_${key}`];
+    if (value !== undefined && String(value).trim()) {
+      return {
+        value: String(value).trim(),
+        source: `ISTARA_BENCHMARK_DONOR_${index}_${key}`,
+      };
+    }
+  }
+  return { value: "", source: "" };
+}
+
+function loadConfiguredDonorProfiles() {
+  const profiles = [];
+  const fileConfig = readJsonConfigFile(
+    process.env.ISTARA_BENCHMARK_DONOR_PROFILES_FILE,
+    "ISTARA_BENCHMARK_DONOR_PROFILES_FILE",
+  );
+  const inlineConfig = parseJsonConfig(
+    process.env.ISTARA_BENCHMARK_DONOR_PROFILES_JSON || "",
+    "ISTARA_BENCHMARK_DONOR_PROFILES_JSON",
+  );
+  for (const config of [fileConfig, inlineConfig]) {
+    if (!config) continue;
+    const list = Array.isArray(config)
+      ? config
+      : (config.donor_profiles || config.donorProfiles || config.donors || []);
+    for (const item of asArray(list)) {
+      if (item && typeof item === "object") profiles.push(item);
+    }
+  }
+  return profiles;
+}
+
+function modelFamilyFromId(model) {
+  const value = String(model || "").toLowerCase();
+  if (value.includes("gemma")) return "gemma";
+  if (value.includes("qwen")) return "qwen";
+  if (value.includes("llama")) return "llama";
+  if (value.includes("mistral")) return "mistral";
+  if (value.includes("claude")) return "anthropic";
+  return value ? "other" : "unset";
+}
+
+const startSandbox = hasFlag("start-sandbox") || ["1", "true", "yes"].includes(String(process.env.ISTARA_BENCHMARK_START_SANDBOX || "").toLowerCase());
+const skipSandbox = ["1", "true", "yes"].includes(String(process.env.ISTARA_BENCHMARK_SKIP_SANDBOX || "").toLowerCase());
+const mode = arg("mode", process.env.ISTARA_BENCHMARK_MODE || "probe");
+const runId = arg("run-id", makeRunId());
+const resultsRoot = resolve(arg("results-dir", process.env.ISTARA_BENCHMARK_RESULTS_DIR || join(__dirname, ".results")));
+const externalConnectionStringMode = boolEnv("ISTARA_BENCHMARK_EXTERNAL_CONNECTION_STRINGS", false)
+  || boolEnv("ISTARA_BENCHMARK_INTERACTIVE_CONNECTION_STRINGS", false)
+  || Boolean(
+    process.env.ISTARA_BENCHMARK_CONNECTION_STRINGS_FILE
+      || process.env.ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRINGS
+      || process.env.ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRING
+      || process.env.ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRINGS
+      || process.env.ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRING,
+  );
+const startClientSandboxes = boolEnv(
+  "ISTARA_BENCHMARK_START_CLIENT_SANDBOXES",
+  startSandbox || externalConnectionStringMode || (mode !== "plan-only" && boolEnv("ISTARA_BENCHMARK_REQUIRE_COMPUTE_DONATION", true)),
+);
+let runtimeResearcherCount = intArg("researcher-count", 1);
+const backendEnv = loadBackendEnv();
+const liveLlmProfile = liveLlmProfileFromTestingContract();
+const requireComputeDonation = boolEnv("ISTARA_BENCHMARK_REQUIRE_COMPUTE_DONATION", mode !== "plan-only");
+const requireLiveChat = boolEnv("ISTARA_BENCHMARK_REQUIRE_LIVE_CHAT", requireComputeDonation || mode === "full");
+const forceDonatedChat = boolEnv("ISTARA_BENCHMARK_FORCE_DONATED_CHAT", requireComputeDonation);
+const defaultApiBase = startSandbox && !skipSandbox ? "http://localhost:18000" : "http://localhost:8000";
+const defaultFrontendUrl = startSandbox && !skipSandbox ? "http://localhost:13000" : "http://localhost:3000";
+const apiBase = (process.env.ISTARA_API_URL || defaultApiBase).replace(/\/$/, "");
+const frontendUrl = (process.env.ISTARA_FRONTEND_URL || defaultFrontendUrl).replace(/\/$/, "");
+const benchmarkAdminUsername = process.env.ISTARA_BENCHMARK_ADMIN_USERNAME || process.env.ISTARA_ADMIN_USERNAME || process.env.ADMIN_USERNAME || "admin";
+const benchmarkAdminPassword = (
+  process.env.ISTARA_BENCHMARK_ADMIN_PASSWORD ||
+  process.env.ISTARA_ADMIN_PASSWORD ||
+  process.env.ADMIN_PASSWORD ||
+  (startSandbox && !skipSandbox ? "IstaraBenchmarkAdmin123!" : "")
+).trim();
+const benchmarkTeamMode = (
+  process.env.ISTARA_BENCHMARK_TEAM_MODE ||
+  (startSandbox && !skipSandbox ? "true" : "")
+).trim();
+const freshSandbox = !["0", "false", "no"].includes(
+  String(process.env.ISTARA_BENCHMARK_FRESH_SANDBOX ?? "1").toLowerCase(),
+);
+const backgroundAgentsDisabled = (
+  process.env.ISTARA_BENCHMARK_DISABLE_BACKGROUND_AGENTS ||
+  (mode === "probe" ? "true" : "false")
+).trim();
+const benchmarkNetworkToken = (
+  process.env.ISTARA_NETWORK_ACCESS_TOKEN ||
+  process.env.NETWORK_ACCESS_TOKEN ||
+  process.env.ISTARA_BENCHMARK_NETWORK_ACCESS_TOKEN ||
+  (requireComputeDonation && startSandbox && !skipSandbox ? `ruben-${randomBytes(24).toString("base64url")}` : "") ||
+  ""
+).trim();
+const configuredLmStudioHost = (
+  liveLlmProfile.baseUrl ||
+  configuredValue(backendEnv, "LMSTUDIO_HOST", "http://host.docker.internal:1234")
+).trim();
+const configuredLmStudioHostSource = liveLlmProfile.baseUrl
+  ? liveLlmProfile.baseUrlSource
+  : backendEnv.__sources?.LMSTUDIO_HOST || "default";
+const relayLlmHostRaw = (
+  process.env.ISTARA_BENCHMARK_RELAY_LLM_HOST ||
+  configuredLmStudioHost
+).trim();
+const relayLlmHostSource = process.env.ISTARA_BENCHMARK_RELAY_LLM_HOST
+  ? "ISTARA_BENCHMARK_RELAY_LLM_HOST"
+  : configuredLmStudioHostSource;
+const relayLlmHostForContainer = replaceLocalhostForContainer(relayLlmHostRaw);
+const explicitRelayLlmProvider = (process.env.ISTARA_BENCHMARK_RELAY_LLM_PROVIDER || "").trim();
+const relayLlmProvider = inferProviderType(explicitRelayLlmProvider || null, relayLlmHostForContainer);
+const relayLlmProviderSource = explicitRelayLlmProvider
+  ? "ISTARA_BENCHMARK_RELAY_LLM_PROVIDER"
+  : liveLlmProfile.baseUrl
+    ? "inferred-from-testing-live-llm-base-url"
+    : "inferred-from-relay-host";
+const relayLlmHost = stripOpenAIPathForNativeLMStudio(relayLlmHostForContainer, relayLlmProvider);
+const relayLlmHostNormalized = relayLlmHost !== relayLlmHostForContainer;
+const relayLlmModel = (
+  process.env.ISTARA_BENCHMARK_RELAY_LLM_MODEL ||
+  liveLlmProfile.model ||
+  configuredValue(backendEnv, "LMSTUDIO_MODEL", "default") ||
+  "default"
+).trim();
+const relayLlmModelSource = process.env.ISTARA_BENCHMARK_RELAY_LLM_MODEL
+  ? "ISTARA_BENCHMARK_RELAY_LLM_MODEL"
+  : liveLlmProfile.modelSource;
+const relayLlmApiKey = (
+  process.env.ISTARA_BENCHMARK_RELAY_LLM_API_KEY ||
+  liveLlmProfile.apiKey ||
+  configuredValue(backendEnv, "LMSTUDIO_API_KEY", "")
+).trim();
+const relayLlmApiKeySource = process.env.ISTARA_BENCHMARK_RELAY_LLM_API_KEY
+  ? "ISTARA_BENCHMARK_RELAY_LLM_API_KEY"
+  : liveLlmProfile.apiKey
+    ? liveLlmProfile.apiKeySource
+    : backendEnv.__sources?.LMSTUDIO_API_KEY || "unset";
+
+function profileValue(profile, keys) {
+  for (const key of keys) {
+    const value = profile?.[key];
+    if (value !== undefined && value !== null && String(value).trim()) return String(value).trim();
+  }
+  return "";
+}
+
+function normalizeDonorProfile(rawProfile, index, { required = true, defaultKind = "" } = {}) {
+  const raw = rawProfile || {};
+  const envHost = envDonorValue(index, ["LLM_HOST", "HOST", "BASE_URL"]);
+  const envProvider = envDonorValue(index, ["LLM_PROVIDER", "PROVIDER"]);
+  const envModel = envDonorValue(index, ["LLM_MODEL", "MODEL"]);
+  const envApiKey = envDonorValue(index, ["LLM_API_KEY", "API_KEY"]);
+  const envApiKeyName = envDonorValue(index, ["LLM_API_KEY_ENV", "API_KEY_ENV"]);
+  const envConnection = envDonorValue(index, ["CONNECTION_STRING", "COMPUTE_CONNECTION_STRING"]);
+  const isFirstLegacyDefault = index === 1 && !defaultKind;
+  const isQwenDefault = defaultKind === "qwen";
+  const profileProvider = profileValue(raw, ["provider", "llm_provider", "llmProvider"]);
+
+  const id = firstNonEmpty(
+    raw.id,
+    raw.name,
+    isQwenDefault ? `donor-${index}-qwen35-4b` : "",
+    isFirstLegacyDefault ? "donor-1-gemma4" : "",
+    `donor-${index}`,
+  ).replace(/[^a-z0-9_-]+/gi, "-").toLowerCase();
+  const rawHost = firstNonEmpty(
+    envHost.value,
+    profileValue(raw, ["llm_host", "llmHost", "host", "base_url", "baseUrl"]),
+    isQwenDefault ? process.env.ISTARA_BENCHMARK_QWEN_LLM_HOST : "",
+    isFirstLegacyDefault ? relayLlmHostRaw : "",
+  );
+  const hostForContainer = replaceLocalhostForContainer(rawHost);
+  const providerRaw = firstNonEmpty(
+    envProvider.value,
+    profileProvider,
+    isQwenDefault ? (process.env.ISTARA_BENCHMARK_QWEN_LLM_PROVIDER || "lmstudio") : "",
+    isFirstLegacyDefault ? relayLlmProvider : "",
+  );
+  const provider = inferProviderType(providerRaw || null, hostForContainer);
+  const host = stripOpenAIPathForNativeLMStudio(hostForContainer, provider);
+  const apiKeyEnvName = firstNonEmpty(
+    envApiKeyName.value,
+    profileValue(raw, ["api_key_env", "apiKeyEnv", "llm_api_key_env", "llmApiKeyEnv"]),
+    isQwenDefault ? process.env.ISTARA_BENCHMARK_QWEN_LLM_API_KEY_ENV : "",
+  );
+  const apiKeyFromNamedEnv = apiKeyEnvName ? String(process.env[apiKeyEnvName] || "").trim() : "";
+  const apiKey = firstNonEmpty(
+    envApiKey.value,
+    apiKeyFromNamedEnv,
+    profileValue(raw, ["api_key", "apiKey", "llm_api_key", "llmApiKey"]),
+    isQwenDefault ? process.env.ISTARA_BENCHMARK_QWEN_LLM_API_KEY : "",
+    isFirstLegacyDefault ? relayLlmApiKey : "",
+  );
+  const model = firstNonEmpty(
+    envModel.value,
+    profileValue(raw, ["model", "llm_model", "llmModel", "model_id", "modelId"]),
+    isQwenDefault ? (process.env.ISTARA_BENCHMARK_QWEN_LLM_MODEL || FUTURE_QWEN_DONOR_MODEL) : "",
+    isFirstLegacyDefault ? relayLlmModel : "",
+    "default",
+  );
+  const connectionString = firstNonEmpty(
+    envConnection.value,
+    profileValue(raw, ["connection_string", "connectionString", "compute_connection_string", "computeConnectionString"]),
+  );
+  const provisionedOnly = Boolean(raw.provisioned_only ?? raw.provisionedOnly ?? isQwenDefault);
+  const disabledByConfig = raw.enabled === false || raw.disabled === true;
+  const enabled = !disabledByConfig && Boolean(host);
+  const blockedReason = enabled
+    ? ""
+    : disabledByConfig
+      ? "donor-disabled-by-config"
+      : "donor-llm-endpoint-not-configured";
+
+  return {
+    id,
+    index,
+    required,
+    enabled,
+    blockedReason,
+    provisionedOnly,
+    provider,
+    providerSource: envProvider.source || (profileProvider ? "donor-profile" : isFirstLegacyDefault ? relayLlmProviderSource : isQwenDefault ? "future-qwen-profile" : providerRaw ? "configured" : "inferred"),
+    hostRaw: rawHost,
+    hostForContainer,
+    host,
+    hostSource: envHost.source || (rawHost ? (isFirstLegacyDefault ? relayLlmHostSource : "donor-profile") : "unset"),
+    hostNormalized: host !== hostForContainer,
+    apiKey,
+    apiKeySource: envApiKey.source || (apiKeyFromNamedEnv ? `env:${apiKeyEnvName}` : isFirstLegacyDefault && apiKey ? relayLlmApiKeySource : apiKey ? "donor-profile" : "unset"),
+    model,
+    modelSource: envModel.source || (isQwenDefault ? "future-qwen-profile" : isFirstLegacyDefault ? relayLlmModelSource : "donor-profile"),
+    modelFamily: modelFamilyFromId(model),
+    connectionString,
+    connectionStringSource: envConnection.source || (connectionString ? "donor-profile" : "unset"),
+  };
+}
+
+function buildDonorProfiles({ donorCountOverride = null } = {}) {
+  const configuredProfiles = loadConfiguredDonorProfiles();
+  const requested = Number.isFinite(donorCountOverride) && donorCountOverride > 0
+    ? donorCountOverride
+    : intArg("donor-count", Math.max(1, configuredProfiles.length || 1));
+  const total = Math.max(requested, configuredProfiles.length, 1);
+  const profiles = [];
+  for (let index = 1; index <= total; index += 1) {
+    const configured = configuredProfiles[index - 1];
+    const defaultKind = configured ? "" : index === 1 ? "" : "qwen";
+    profiles.push(normalizeDonorProfile(configured || {}, index, {
+      required: index <= requested,
+      defaultKind,
+    }));
+  }
+  return profiles;
+}
+
+function summarizeDonorProfile(profile) {
+  return {
+    id: profile.id,
+    index: profile.index,
+    required: Boolean(profile.required),
+    enabled: Boolean(profile.enabled),
+    blocked_reason: profile.blockedReason || "",
+    provisioned_only: Boolean(profile.provisionedOnly),
+    provider: profile.provider,
+    provider_source: profile.providerSource,
+    host: hostSummary(profile.host),
+    host_source: profile.hostSource,
+    host_localhost_translated_for_container: profile.hostRaw !== profile.hostForContainer,
+    host_openai_path_stripped_for_native_lmstudio: Boolean(profile.hostNormalized),
+    api_key_configured: Boolean(profile.apiKey),
+    api_key_source: profile.apiKeySource,
+    model_family: profile.modelFamily,
+    model_configured: Boolean(profile.model && profile.model !== "default"),
+    model_source: profile.modelSource,
+    model_id_redacted: true,
+    connection_string_configured: Boolean(profile.connectionString),
+    connection_string_source: profile.connectionStringSource,
+  };
+}
+
+let donorProfiles = buildDonorProfiles();
+const serverLmstudioModel = (
+  process.env.ISTARA_BENCHMARK_SERVER_LMSTUDIO_MODEL ||
+  relayLlmModel ||
+  "default"
+).trim();
+const serverLlmProvider = (
+  process.env.ISTARA_BENCHMARK_SERVER_LLM_PROVIDER ||
+  (forceDonatedChat ? "lmstudio" : "ollama")
+).trim();
+const serverLmstudioHost = forceDonatedChat
+  ? "http://127.0.0.1:9"
+  : stripOpenAIPathForNativeLMStudio(
+      replaceLocalhostForContainer(process.env.ISTARA_BENCHMARK_SERVER_LMSTUDIO_HOST || configuredLmStudioHost),
+      inferProviderType(serverLlmProvider, configuredLmStudioHost),
+    );
+const serverOllamaHost = (
+  process.env.ISTARA_BENCHMARK_SERVER_OLLAMA_HOST ||
+  (forceDonatedChat ? "http://127.0.0.1:9" : "http://ollama:11434")
+).trim();
+const serverNeedsOllama = serverLlmProvider === "ollama" && !forceDonatedChat;
+const serverLmstudioAutoLoadEnabled = (
+  process.env.ISTARA_BENCHMARK_LMSTUDIO_AUTO_LOAD_ENABLED ||
+  (requireComputeDonation ? "true" : "false")
+).trim();
+const serverLmstudioAutoContextReload = (
+  process.env.ISTARA_BENCHMARK_LMSTUDIO_AUTO_CONTEXT_RELOAD ||
+  (requireComputeDonation ? "true" : "false")
+).trim();
+const serverStrictAutoRouting = (
+  process.env.ISTARA_BENCHMARK_STRICT_AUTO_ROUTING ||
+  (requireComputeDonation ? "true" : "false")
+).trim();
+const maxChatTurns = intArg("max-chat-turns", mode === "full" ? 100 : mode === "probe" ? 8 : 0);
+const maxTasks = intArg("max-tasks", mode === "full" ? 55 : mode === "probe" ? 8 : 0);
+const maxUploads = intArg("max-uploads", mode === "full" ? 80 : mode === "probe" ? 14 : 0);
+const chatTimeoutMs = intArg("chat-timeout-ms", 120000);
+const keepClientContainers = ["1", "true", "yes"].includes(
+  String(process.env.ISTARA_BENCHMARK_KEEP_CLIENT_CONTAINERS || "").toLowerCase(),
+);
+const colimaStoragePolicy = (process.env.ISTARA_BENCHMARK_COLIMA_STORAGE_POLICY || "warn").trim().toLowerCase();
+const colimaStorageBudget = {
+  actualGb: floatEnv("ISTARA_BENCHMARK_COLIMA_MAX_ACTUAL_GB", 10),
+  apparentGb: floatEnv("ISTARA_BENCHMARK_COLIMA_MAX_APPARENT_GB", 20),
+  toleranceGb: floatEnv("ISTARA_BENCHMARK_COLIMA_STORAGE_TOLERANCE_GB", 0.25),
+};
+let latestColimaStorageSnapshot = null;
+
+const logger = new BenchmarkLogger({ rootDir: resultsRoot, runId, mode });
+logger.init();
+logger.writeJson("run-metadata.json", {
+  run_id: runId,
+  mode,
+  started_at: new Date().toISOString(),
+  cwd: process.cwd(),
+  node: process.version,
+  system_prompt: {
+    source_path: systemPromptPath,
+    version: systemPromptVersion,
+    sha256: systemPromptHash,
+    bytes: Buffer.byteLength(systemPromptContent, "utf8"),
+  },
+});
+logger.writeText("system-prompt.md", systemPromptContent);
+logger.writeJson("benchmark-registry-snapshot.json", benchmarkRegistry);
+logger.action("system_prompt.loaded", {
+  source_path: systemPromptPath,
+  version: systemPromptVersion,
+  sha256: systemPromptHash,
+  bytes: Buffer.byteLength(systemPromptContent, "utf8"),
+});
+for (const warning of startupConfigWarnings) {
+  logger.action("config.warning", warning);
+}
+logger.action("llm.config.sources", {
+  relay_provider: relayLlmProvider,
+  relay_provider_source: relayLlmProviderSource,
+  live_base_url_configured: Boolean(liveLlmProfile.baseUrl),
+  live_base_url_key: liveLlmProfile.baseUrlKey || "unset",
+  live_base_url_source: liveLlmProfile.baseUrlSource,
+  live_env_files_with_relevant_keys: liveLlmProfile.loadedEnvFiles,
+  relay_host_source: relayLlmHostSource,
+  relay_host: hostSummary(relayLlmHost),
+  relay_host_localhost_translated_for_container: relayLlmHostRaw !== relayLlmHostForContainer,
+  relay_host_openai_path_stripped_for_native_lmstudio: relayLlmHostNormalized,
+  relay_model_source: relayLlmModelSource,
+  relay_api_key_source: relayLlmApiKeySource,
+  start_client_sandboxes: startClientSandboxes,
+  external_connection_string_mode: externalConnectionStringMode,
+  researcher_count: runtimeResearcherCount,
+  donor_count_requested: donorProfiles.filter((profile) => profile.required).length,
+  donor_profiles: donorProfiles.map(summarizeDonorProfile),
+  keychain_service_configured: liveLlmProfile.keychainServiceConfigured,
+  keychain_service_source: liveLlmProfile.keychainServiceSource,
+  model_configured: Boolean(relayLlmModel && relayLlmModel !== "default"),
+  model_id_redacted: true,
+  api_key_configured: Boolean(relayLlmApiKey),
+  server_needs_ollama: serverNeedsOllama,
+  server_lmstudio_auto_load_enabled: serverLmstudioAutoLoadEnabled,
+  server_lmstudio_auto_context_reload: serverLmstudioAutoContextReload,
+  server_strict_auto_routing: serverStrictAutoRouting,
+});
+logger.action("benchmark.registry.loaded", {
+  registry_version: benchmarkRegistry.version,
+  companion_suites: benchmarkRegistry.companion_suites?.map((suite) => suite.path) || [],
+  live_model_profile: benchmarkRegistry.live_model_profile || {},
+  agentic_eval_focus: benchmarkRegistry.agentic_eval_focus?.map((item) => item.area) || [],
+  future_multi_donor_profiles: benchmarkRegistry.future_multi_donor_profiles?.map((item) => ({
+    id: item.id,
+    enabled_by_default: Boolean(item.enabled_by_default),
+    model_download_allowed: Boolean(item.model_download_allowed),
+  })) || [],
+});
+logger.appendReport(`# Istara Real User Benchmark Report\n\nRun ID: ${runId}\nMode: ${mode}\nStarted: ${new Date().toISOString()}\n\n`);
+
+const blockers = [];
+const featureResults = {
+  uiVisited: false,
+  uiOnboarding: false,
+  uploadedAndQueried: false,
+  citedSources: false,
+  findingsCreated: false,
+  reportGenerated: false,
+  loops: false,
+  urlFetch: false,
+  interfaces: false,
+  multiDonorCompute: false,
+};
+
+const sandbox = {
+  serverAttempted: false,
+  serverStarted: false,
+  clientAttempted: false,
+  clientStarted: false,
+  relayAttempted: false,
+  relayStarted: false,
+  clientSandboxRequested: startClientSandboxes,
+  relayExpectedCount: donorProfiles.filter((profile) => profile.required).length,
+  relayStartedCount: 0,
+  researcherExpectedCount: runtimeResearcherCount,
+  researcherStartedCount: 0,
+};
+const relayClientContainers = [];
+const extraSensitiveLogValues = new Set();
+let relayClientImageBuilt = false;
+let clientDockerReady = null;
+
+function redactForLog(value) {
+  if (typeof value !== "string") return value;
+  if (value.startsWith("rcl_")) return `${value.slice(0, 18)}...[redacted:${value.length}]`;
+  return value.replace(/rcl_[A-Za-z0-9_.-]{24,}/g, (match) => `${match.slice(0, 18)}...[redacted:${match.length}]`);
+}
+
+function sensitiveLogValues() {
+  return [
+    benchmarkNetworkToken,
+    liveLlmProfile.baseUrl,
+    relayLlmHostRaw,
+    relayLlmHostForContainer,
+    relayLlmHost,
+    relayLlmModel,
+    relayLlmApiKey,
+    ...donorProfiles.flatMap((profile) => [
+      profile.hostRaw,
+      profile.hostForContainer,
+      profile.host,
+      profile.apiKey,
+      profile.connectionString,
+      profile.model,
+    ]),
+    configuredLmStudioHost,
+    serverLmstudioHost,
+    serverLmstudioModel,
+    serverOllamaHost,
+    ...Array.from(extraSensitiveLogValues),
+  ].filter((value) => typeof value === "string" && value.length > 0 && value !== "default");
+}
+
+function sanitizeLogText(text) {
+  let output = redactForLog(String(text || ""));
+  for (const value of sensitiveLogValues()) {
+    const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    output = output.replace(new RegExp(escaped, "g"), `[redacted:${value.length}]`);
+  }
+  output = output.replace(/Failed to load LLM '([^']+)'/g, "Failed to load LLM '[redacted-model]'");
+  output = output.replace(/failed to load model \S+ on/gi, "failed to load model [redacted-model] on");
+  output = output.replace(/Model load failed: \S+:/g, "Model load failed: [redacted-model]:");
+  return output;
+}
+
+function redactArgForLog(value, index, args) {
+  const previous = args[index - 1] || "";
+  if (["--llm-host", "--llm-api-key", "--model"].includes(previous)) {
+    return `[redacted-arg:${String(value || "").length}]`;
+  }
+  return sanitizeLogText(value);
+}
+
+function runCommand(label, command, args, options = {}) {
+  const started = Date.now();
+  const loggedArgs = args.map((value, index) => redactArgForLog(value, index, args));
+  logger.action("command.start", { label, command, args: loggedArgs });
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || repoRoot,
+    encoding: "utf8",
+    timeout: options.timeoutMs || 15 * 60 * 1000,
+    env: { ...process.env, ...(options.env || {}) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const payload = {
+    label,
+    command,
+    args: loggedArgs,
+    status: result.status,
+    signal: result.signal,
+    duration_ms: Date.now() - started,
+    stdout: sanitizeLogText(result.stdout || "").slice(-12000),
+    stderr: sanitizeLogText(result.stderr || "").slice(-12000),
+    error: sanitizeLogText(result.error?.message || ""),
+  };
+  logger.action("command.finish", payload);
+  logger.writeText(`logs/${label.replace(/[^a-z0-9_-]+/gi, "-")}.log`, [
+    `$ ${command} ${loggedArgs.join(" ")}`,
+    "",
+    "## stdout",
+    payload.stdout,
+    "",
+    "## stderr",
+    payload.stderr,
+    payload.error ? `\n## error\n${payload.error}` : "",
+  ].join("\n"));
+  return result;
+}
+
+function pruneDanglingDockerImages(label) {
+  if (!boolEnv("ISTARA_BENCHMARK_PRUNE_DANGLING_IMAGES", true)) {
+    logger.action("docker.prune_dangling.skip", { label });
+    return;
+  }
+  runCommand(`docker-prune-dangling-${label}`, "docker", ["image", "prune", "-f"], {
+    timeoutMs: 5 * 60 * 1000,
+  });
+}
+
+function hasExecutable(command) {
+  const result = spawnSync("sh", ["-lc", `command -v ${command}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return result.status === 0 && Boolean(result.stdout.trim());
+}
+
+function dockerDaemonIsReady() {
+  const result = spawnSync("docker", ["info", "--format", "{{.ServerVersion}}"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    status: result.status,
+  };
+}
+
+function formatGiB(bytes) {
+  return Number((bytes / (1024 ** 3)).toFixed(2));
+}
+
+function readDuKiB(target, apparent = false) {
+  if (!existsSync(target)) {
+    return { ok: false, path: target, kib: 0, gib: 0, supported: true, reason: "missing" };
+  }
+  const attempts = apparent
+    ? [["-sk", "-A", target], ["-sk", "--apparent-size", target]]
+    : [["-sk", target]];
+  for (const args of attempts) {
+    const result = spawnSync("du", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0) continue;
+    const kib = Number.parseInt(String(result.stdout || "").trim().split(/\s+/)[0], 10);
+    if (Number.isFinite(kib)) {
+      return {
+        ok: true,
+        path: target,
+        kib,
+        gib: formatGiB(kib * 1024),
+        supported: true,
+      };
+    }
+  }
+  return { ok: false, path: target, kib: 0, gib: 0, supported: false, reason: "du-unsupported" };
+}
+
+function summarizeColimaStorage(snapshot) {
+  const total = snapshot?.paths?.find((entry) => entry.name === "colima-home");
+  return total
+    ? {
+        actual_gb: total.actual?.gib ?? null,
+        apparent_gb: total.apparent?.gib ?? null,
+        over_budget: snapshot.over_budget || [],
+      }
+    : null;
+}
+
+function captureColimaStorageSnapshot(label, { recordIssue = false } = {}) {
+  const home = process.env.HOME || "";
+  if (!home) return null;
+  const paths = [
+    { name: "colima-home", path: join(home, ".colima") },
+    { name: "lima-disks", path: join(home, ".colima", "_lima", "_disks") },
+    { name: "lima-colima-profile", path: join(home, ".colima", "_lima", "colima") },
+  ];
+  const entries = paths.map((item) => ({
+    ...item,
+    exists: existsSync(item.path),
+    actual: readDuKiB(item.path, false),
+    apparent: readDuKiB(item.path, true),
+  }));
+  const total = entries.find((entry) => entry.name === "colima-home");
+  const overBudget = [];
+  if (total?.actual?.ok && total.actual.gib > colimaStorageBudget.actualGb + colimaStorageBudget.toleranceGb) {
+    overBudget.push({
+      measure: "actual",
+      path: total.path,
+      observed_gb: total.actual.gib,
+      budget_gb: colimaStorageBudget.actualGb,
+    });
+  }
+  if (total?.apparent?.ok && total.apparent.gib > colimaStorageBudget.apparentGb + colimaStorageBudget.toleranceGb) {
+    overBudget.push({
+      measure: "apparent",
+      path: total.path,
+      observed_gb: total.apparent.gib,
+      budget_gb: colimaStorageBudget.apparentGb,
+    });
+  }
+  const snapshot = {
+    label,
+    captured_at: new Date().toISOString(),
+    policy: colimaStoragePolicy,
+    budgets_gb: colimaStorageBudget,
+    paths: entries,
+    over_budget: overBudget,
+    remediation: overBudget.length
+      ? "Use a fresh Colima profile with --root-disk 10 --disk 10, or explicitly raise ISTARA_BENCHMARK_COLIMA_MAX_*_GB for larger benchmark images."
+      : "",
+  };
+  latestColimaStorageSnapshot = snapshot;
+  logger.action("storage.colima.snapshot", snapshot);
+  logger.writeJson(`storage/colima-${label.replace(/[^a-z0-9_-]+/gi, "-")}.json`, snapshot);
+  if (recordIssue && overBudget.length) {
+    logger.issue({
+      area: "storage",
+      severity: colimaStoragePolicy === "fail" ? "critical" : "medium",
+      title: "Colima storage budget exceeded",
+      detail: overBudget.map((item) => `${item.measure} ${item.observed_gb}GB > ${item.budget_gb}GB`).join("; "),
+    });
+    if (colimaStoragePolicy === "fail") {
+      blockers.push(`Colima storage budget exceeded: ${overBudget.map((item) => `${item.measure} ${item.observed_gb}GB>${item.budget_gb}GB`).join(", ")}`);
+    }
+  }
+  return snapshot;
+}
+
+function dockerHostAccessArgs() {
+  return process.platform === "linux" ? ["--add-host", "host.docker.internal:host-gateway"] : [];
+}
+
+function containerReachableUrl(url) {
+  return replaceLocalhostForContainer(url).replace(/\/$/, "");
+}
+
+function ensureDockerDaemon() {
+  const first = dockerDaemonIsReady();
+  if (first.ok) {
+    logger.action("docker.daemon.ready", { server_version: first.stdout.trim() });
+    return first;
+  }
+
+  logger.action("docker.daemon.unavailable", {
+    status: first.status,
+    stderr: first.stderr.slice(0, 800),
+  });
+
+  const allowColimaAutostart = !["0", "false", "no"].includes(
+    String(process.env.ISTARA_BENCHMARK_AUTOSTART_COLIMA ?? "1").toLowerCase(),
+  );
+  if (!allowColimaAutostart || !hasExecutable("colima")) {
+    return first;
+  }
+
+  captureColimaStorageSnapshot("before-colima-autostart", { recordIssue: true });
+  const cpu = process.env.ISTARA_BENCHMARK_COLIMA_CPU || "4";
+  const memory = process.env.ISTARA_BENCHMARK_COLIMA_MEMORY || "6";
+  const disk = process.env.ISTARA_BENCHMARK_COLIMA_DISK || "10";
+  const rootDisk = process.env.ISTARA_BENCHMARK_COLIMA_ROOT_DISK || "10";
+  logger.action("colima.autostart.config", {
+    cpu,
+    memory_gb: memory,
+    disk_gb: disk,
+    root_disk_gb: rootDisk,
+    storage_policy: colimaStoragePolicy,
+    budgets_gb: colimaStorageBudget,
+  });
+  runCommand("colima-start", "colima", [
+    "start",
+    "--cpu",
+    cpu,
+    "--memory",
+    memory,
+    "--disk",
+    disk,
+    "--root-disk",
+    rootDisk,
+    "--runtime",
+    "docker",
+  ], {
+    timeoutMs: 15 * 60 * 1000,
+  });
+  captureColimaStorageSnapshot("after-colima-autostart", { recordIssue: true });
+  const second = dockerDaemonIsReady();
+  logger.action("docker.daemon.after_colima", {
+    ok: second.ok,
+    server_version: second.stdout.trim(),
+    stderr: second.stderr.slice(0, 800),
+  });
+  return second;
+}
+
+function ensureClientDockerDaemon(label) {
+  if (!startClientSandboxes) {
+    logger.action("docker.client_daemon.skip", { label, startClientSandboxes });
+    return { ok: false, skipped: true };
+  }
+  if (clientDockerReady) return clientDockerReady;
+  clientDockerReady = ensureDockerDaemon();
+  if (!clientDockerReady.ok) {
+    blockers.push("Client/donor sandbox containers could not start because Docker was unavailable.");
+    logger.issue({
+      area: "client-install",
+      severity: "critical",
+      title: "Docker unavailable for client/donor sandboxes",
+      detail: clientDockerReady.stderr || clientDockerReady.stdout || "docker info failed",
+    });
+  }
+  return clientDockerReady;
+}
+
+function composeCommand() {
+  const configArgs = [
+    "-p",
+    "istara-real-user-benchmark-server",
+    "-f",
+    "docker-compose.yml",
+    "-f",
+    "tests/real_user_benchmark/docker-compose.benchmark.yml",
+    "config",
+    "--services",
+  ];
+  const errors = [];
+  const plugin = spawnSync("docker", ["compose", "version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (plugin.status === 0) {
+    const config = spawnSync("docker", ["compose", ...configArgs], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (config.status === 0) {
+      return { command: "docker", prefixArgs: ["compose"], flavor: "docker compose" };
+    }
+    errors.push(`docker compose config failed: ${(config.stderr || config.stdout || "").slice(0, 500)}`);
+  } else {
+    errors.push((plugin.stderr || plugin.stdout || "docker compose not available").slice(0, 500));
+  }
+  if (hasExecutable("docker-compose")) {
+    const legacy = spawnSync("docker-compose", ["version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (legacy.status === 0) {
+      const config = spawnSync("docker-compose", configArgs, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (config.status === 0) {
+        return { command: "docker-compose", prefixArgs: [], flavor: "docker-compose" };
+      }
+      errors.push(`docker-compose config failed: ${(config.stderr || config.stdout || "").slice(0, 500)}`);
+    }
+  }
+  return {
+    command: "",
+    prefixArgs: [],
+    flavor: "none",
+    error: errors.join("\n").slice(0, 1200) || "No Docker Compose command found.",
+  };
+}
+
+async function waitForHealth(api, timeoutMs = 180000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const health = await api.health();
+    logger.action("health.poll", health);
+    if (health.ok) return health;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 3000));
+  }
+  return { ok: false, error: "Timed out waiting for /api/health" };
+}
+
+function startServerSandboxIfRequested() {
+  if (!startSandbox || skipSandbox || mode === "plan-only") {
+    logger.action("sandbox.server.skip", { startSandbox, skipSandbox, mode });
+    return;
+  }
+  sandbox.serverAttempted = true;
+  const model = process.env.ISTARA_BENCHMARK_LLM_MODEL || process.env.OLLAMA_MODEL || "qwen3:latest";
+  const profile = process.env.ISTARA_BENCHMARK_LLM_PROFILE || "local-bounded";
+  logger.action("sandbox.server.llm_profile", {
+    profile,
+    provider: serverLlmProvider,
+    model_configured: Boolean(serverLmstudioModel),
+    model_id_redacted: true,
+    forceDonatedChat,
+    relay_provider: relayLlmProvider,
+    relay_provider_source: relayLlmProviderSource,
+    relay_host: hostSummary(relayLlmHost),
+    relay_host_source: relayLlmHostSource,
+    relay_host_localhost_translated_for_container: relayLlmHostRaw !== relayLlmHostForContainer,
+    relay_host_openai_path_stripped_for_native_lmstudio: relayLlmHostNormalized,
+    relay_api_key_configured: Boolean(relayLlmApiKey),
+    relay_api_key_source: relayLlmApiKeySource,
+    relay_model_source: relayLlmModelSource,
+    donor_profiles: donorProfiles.map(summarizeDonorProfile),
+    server_needs_ollama: serverNeedsOllama,
+    server_lmstudio_auto_load_enabled: serverLmstudioAutoLoadEnabled,
+    server_lmstudio_auto_context_reload: serverLmstudioAutoContextReload,
+    server_strict_auto_routing: serverStrictAutoRouting,
+    note: "Benchmark is bounded to this single configured LLM model/profile. Sensitive endpoint and model values are redacted.",
+  });
+  const daemon = ensureDockerDaemon();
+  let result;
+  if (!daemon.ok) {
+    result = { status: daemon.status || 1, stderr: daemon.stderr, stdout: daemon.stdout };
+  } else {
+    const compose = composeCommand();
+    logger.action("docker.compose.detected", { flavor: compose.flavor, error: compose.error || "" });
+    if (compose.command) {
+      const composeBaseArgs = [
+        ...compose.prefixArgs,
+        "-p",
+        "istara-real-user-benchmark-server",
+        "-f",
+        "docker-compose.yml",
+        "-f",
+        "tests/real_user_benchmark/docker-compose.benchmark.yml",
+      ];
+      if (freshSandbox) {
+        runCommand("docker-compose-server-down", compose.command, [
+          ...composeBaseArgs,
+          "down",
+          "--remove-orphans",
+        ], {
+          env: {
+            ISTARA_BENCHMARK_TEAM_MODE: benchmarkTeamMode,
+            ISTARA_BENCHMARK_ADMIN_USERNAME: benchmarkAdminUsername,
+            ISTARA_BENCHMARK_ADMIN_PASSWORD: benchmarkAdminPassword,
+            ISTARA_BENCHMARK_DISABLE_BACKGROUND_AGENTS: backgroundAgentsDisabled,
+            NETWORK_ACCESS_TOKEN: benchmarkNetworkToken,
+            ISTARA_BENCHMARK_SERVER_LLM_PROVIDER: serverLlmProvider,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_HOST: serverLmstudioHost,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_MODEL: serverLmstudioModel,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_API_KEY: forceDonatedChat ? "" : relayLlmApiKey,
+            ISTARA_BENCHMARK_LMSTUDIO_AUTO_LOAD_ENABLED: serverLmstudioAutoLoadEnabled,
+            ISTARA_BENCHMARK_LMSTUDIO_AUTO_CONTEXT_RELOAD: serverLmstudioAutoContextReload,
+            ISTARA_BENCHMARK_STRICT_AUTO_ROUTING: serverStrictAutoRouting,
+            ISTARA_BENCHMARK_SERVER_OLLAMA_HOST: serverOllamaHost,
+          },
+          timeoutMs: 5 * 60 * 1000,
+        });
+        for (const volumeName of [
+          "istara-real-user-benchmark-server_istara_benchmark_backend_data",
+          "istara-real-user-benchmark-server_istara_benchmark_watch",
+        ]) {
+          runCommand(`docker-volume-rm-${volumeName}`, "docker", ["volume", "rm", volumeName], {
+            timeoutMs: 60 * 1000,
+          });
+        }
+      }
+      const composeArgs = [
+        ...composeBaseArgs,
+        "up",
+        "-d",
+        "--build",
+        ...(serverNeedsOllama ? [] : ["--no-deps"]),
+        "backend",
+        "frontend",
+      ];
+      result = runCommand(
+        "docker-compose-server-up",
+        compose.command,
+        composeArgs,
+        {
+          env: {
+            OLLAMA_MODEL: model,
+            ISTARA_FIXED_LLM_TEST_MODEL: model,
+            ISTARA_BENCHMARK_TEAM_MODE: benchmarkTeamMode,
+            ISTARA_BENCHMARK_ADMIN_USERNAME: benchmarkAdminUsername,
+            ISTARA_BENCHMARK_ADMIN_PASSWORD: benchmarkAdminPassword,
+            ISTARA_BENCHMARK_DISABLE_BACKGROUND_AGENTS: backgroundAgentsDisabled,
+            NETWORK_ACCESS_TOKEN: benchmarkNetworkToken,
+            ISTARA_BENCHMARK_SERVER_LLM_PROVIDER: serverLlmProvider,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_HOST: serverLmstudioHost,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_MODEL: serverLmstudioModel,
+            ISTARA_BENCHMARK_SERVER_LMSTUDIO_API_KEY: forceDonatedChat ? "" : relayLlmApiKey,
+            ISTARA_BENCHMARK_LMSTUDIO_AUTO_LOAD_ENABLED: serverLmstudioAutoLoadEnabled,
+            ISTARA_BENCHMARK_LMSTUDIO_AUTO_CONTEXT_RELOAD: serverLmstudioAutoContextReload,
+            ISTARA_BENCHMARK_STRICT_AUTO_ROUTING: serverStrictAutoRouting,
+            ISTARA_BENCHMARK_SERVER_OLLAMA_HOST: serverOllamaHost,
+          },
+          timeoutMs: 25 * 60 * 1000,
+        },
+      );
+      if (result.status === 0) {
+        pruneDanglingDockerImages("server-compose-build");
+      }
+    } else {
+      logger.action("docker.compose.unavailable", { error: compose.error || "" });
+      result = startServerSandboxWithDocker(model);
+    }
+  }
+  sandbox.serverStarted = result.status === 0;
+  if (!sandbox.serverStarted) {
+    blockers.push("Server sandbox did not start successfully. See logs/docker-* in the run folder.");
+    logger.issue({
+      area: "install",
+      severity: "high",
+      title: "Server sandbox start failed",
+      detail: result.stderr || result.error?.message || "docker compose returned non-zero status",
+    });
+  }
+}
+
+function startServerSandboxWithDocker(model) {
+  const network = "istara-real-user-benchmark-net";
+  const commands = [
+    ["docker", ["rm", "-f", "istara-benchmark-frontend", "istara-benchmark-backend", "istara-benchmark-ollama"], { allowFailure: true }],
+    ["docker", ["network", "create", network], { allowFailure: true }],
+    ...(freshSandbox ? [["docker", ["volume", "rm", "istara_benchmark_backend_data"], { allowFailure: true }]] : []),
+    ...(serverNeedsOllama ? [["docker", ["volume", "create", "istara_benchmark_ollama"], {}]] : []),
+    ["docker", ["volume", "create", "istara_benchmark_backend_data"], {}],
+    ...(serverNeedsOllama ? [["docker", [
+      "run",
+      "-d",
+      "--name",
+      "istara-benchmark-ollama",
+      "--network",
+      network,
+      "-v",
+      "istara_benchmark_ollama:/root/.ollama",
+      "ollama/ollama:latest",
+    ], { timeoutMs: 10 * 60 * 1000 }]] : []),
+    ["docker", [
+      "build",
+      "--build-arg",
+      `INSTALL_WHISPER=${process.env.ISTARA_BENCHMARK_INSTALL_WHISPER || "false"}`,
+      "-t",
+      "istara-real-user-benchmark-backend",
+      "backend",
+    ], { timeoutMs: 25 * 60 * 1000 }],
+    ["docker", [
+      "run",
+      "-d",
+      "--name",
+      "istara-benchmark-backend",
+      "--network",
+      network,
+      ...dockerHostAccessArgs(),
+      "-p",
+      "18000:8000",
+      "-v",
+      "istara_benchmark_backend_data:/app/data",
+      "-e",
+      "DATABASE_URL=sqlite+aiosqlite:///./data/istara.db",
+      "-e",
+      "LANCE_DB_PATH=./data/lance_db",
+      "-e",
+      "UPLOAD_DIR=./data/uploads",
+      "-e",
+      "PROJECTS_DIR=./data/projects",
+      "-e",
+      `LLM_PROVIDER=${serverLlmProvider}`,
+      "-e",
+      `LMSTUDIO_AUTO_LOAD_ENABLED=${serverLmstudioAutoLoadEnabled}`,
+      "-e",
+      `LMSTUDIO_AUTO_CONTEXT_RELOAD=${serverLmstudioAutoContextReload}`,
+      "-e",
+      `STRICT_AUTO_ROUTING=${serverStrictAutoRouting}`,
+      "-e",
+      "LMSTUDIO_MAX_LOAD_ATTEMPTS_PER_REQUEST=1",
+      "-e",
+      "LLM_CAPABILITY_ACTIVE_PROBE_ENABLED=false",
+      "-e",
+      `LMSTUDIO_HOST=${serverLmstudioHost}`,
+      "-e",
+      `LMSTUDIO_MODEL=${serverLmstudioModel}`,
+      "-e",
+      `LMSTUDIO_API_KEY=${forceDonatedChat ? "" : relayLlmApiKey}`,
+      "-e",
+      `TEAM_MODE=${benchmarkTeamMode || "true"}`,
+      "-e",
+      `ADMIN_USERNAME=${benchmarkAdminUsername}`,
+      "-e",
+      `ADMIN_PASSWORD=${benchmarkAdminPassword}`,
+      "-e",
+      "RATE_LIMIT_ENABLED=false",
+      "-e",
+      "JWT_SECRET=istara-real-user-benchmark-jwt-secret",
+      "-e",
+      `NETWORK_ACCESS_TOKEN=${benchmarkNetworkToken}`,
+      "-e",
+      "CORS_ORIGINS=http://localhost:13000,http://127.0.0.1:13000",
+      "-e",
+      `OLLAMA_HOST=${serverOllamaHost}`,
+      "-e",
+      `OLLAMA_MODEL=${model}`,
+      "-e",
+      "AUTORESEARCH_ENABLED=false",
+      "-e",
+      "MCP_SERVER_ENABLED=false",
+      "-e",
+      `ISTARA_DISABLE_BACKGROUND_AGENTS=${backgroundAgentsDisabled}`,
+      "istara-real-user-benchmark-backend",
+    ], { timeoutMs: 2 * 60 * 1000 }],
+    ["docker", [
+      "build",
+      "-t",
+      "istara-real-user-benchmark-frontend",
+      "--build-arg",
+      "NEXT_PUBLIC_API_URL=http://localhost:18000",
+      "--build-arg",
+      "NEXT_PUBLIC_WS_URL=ws://localhost:18000",
+      "frontend",
+    ], { timeoutMs: 25 * 60 * 1000 }],
+    ["docker", [
+      "run",
+      "-d",
+      "--name",
+      "istara-benchmark-frontend",
+      "--network",
+      network,
+      "-p",
+      "13000:3000",
+      "-e",
+      "NEXT_PUBLIC_API_URL=http://localhost:18000",
+      "-e",
+      "NEXT_PUBLIC_WS_URL=ws://localhost:18000",
+      "istara-real-user-benchmark-frontend",
+    ], { timeoutMs: 2 * 60 * 1000 }],
+  ];
+
+  let final = { status: 0 };
+  for (const [command, args, options] of commands) {
+    const label = `docker-manual-${args.slice(0, 3).join("-")}`.replace(/[^a-z0-9_-]+/gi, "-");
+    const result = runCommand(label, command, args, options);
+    if (result.status !== 0 && !options.allowFailure) {
+      final = result;
+      break;
+    }
+  }
+  if (final.status === 0) {
+    pruneDanglingDockerImages("server-manual-build");
+  }
+  return final;
+}
+
+function ensureRelayClientImage() {
+  if (relayClientImageBuilt) return true;
+  const daemon = ensureClientDockerDaemon("relay-client-build");
+  if (!daemon.ok) return false;
+  const build = runCommand("docker-build-relay-client", "docker", ["build", "-t", "istara-real-user-benchmark-relay", "relay"], {
+    timeoutMs: 10 * 60 * 1000,
+  });
+  if (build.status !== 0) {
+    blockers.push("Relay/client sandbox image did not build.");
+    return false;
+  }
+  pruneDanglingDockerImages("relay-client-build");
+  relayClientImageBuilt = true;
+  return true;
+}
+
+function startRelayClientSandbox(connectionString, donorProfile = donorProfiles[0], donorIndex = 0) {
+  const donor = donorProfile || donorProfiles[0];
+  if (!startClientSandboxes || !connectionString || mode === "plan-only") {
+    logger.action("sandbox.relay.skip", {
+      donor_id: donor?.id || `donor-${donorIndex + 1}`,
+      hasConnectionString: Boolean(connectionString),
+      startClientSandboxes,
+      mode,
+    });
+    return;
+  }
+  if (!donor?.enabled) {
+    if (donor?.required || requireComputeDonation) {
+      blockers.push(`Compute donor ${donor?.id || donorIndex + 1} could not start: ${donor?.blockedReason || "profile disabled"}.`);
+      logger.issue({
+        area: "compute-donation",
+        severity: "critical",
+        title: "Required donor profile is not runnable",
+        detail: `Donor ${donor?.id || donorIndex + 1}: ${donor?.blockedReason || "profile disabled"}`,
+      });
+    }
+    logger.action("sandbox.relay.profile_skip", {
+      donor: summarizeDonorProfile(donor),
+    });
+    return;
+  }
+  sandbox.relayAttempted = true;
+  if (!benchmarkNetworkToken) {
+    if (requireComputeDonation) {
+      blockers.push("Compute donation was required, but no network access token was available for relay authentication.");
+      logger.issue({
+        area: "compute-donation",
+        severity: "critical",
+        title: "Missing network access token for required compute donation",
+        detail: "Relay connections to /ws/relay require either a network token or JWT. The benchmark could not start a donated-compute client without one.",
+      });
+    }
+    logger.action("sandbox.relay.skip", {
+      donor_id: donor.id,
+      reason: "The default UI benchmark profile runs Team Mode without NETWORK_ACCESS_TOKEN so browser API requests are not blocked. Set ISTARA_BENCHMARK_NETWORK_ACCESS_TOKEN to live-test compute relay connection strings in a separate profile.",
+    });
+    return;
+  }
+  if (!ensureRelayClientImage()) return;
+  const containerName = `istara-rub-relay-${runId}-${donor.id}`.replace(/[^a-z0-9_.-]+/gi, "-").slice(0, 120);
+  rememberConnectionStringSensitiveValues(connectionString);
+  const relayConnection = rewriteRelayConnectionStringForContainer(connectionString);
+  rememberConnectionStringSensitiveValues(relayConnection.connectionString);
+  const relayBootstrapScript = [
+    "mkdir -p \"$HOME/.istara\"",
+    "node -e 'const fs=require(\"fs\"); const cfg={connection_string:process.env.ISTARA_CONNECTION_STRING, provider:process.env.ISTARA_RELAY_LLM_PROVIDER, llm_host:process.env.ISTARA_RELAY_LLM_HOST, llm_api_key:process.env.ISTARA_RELAY_LLM_API_KEY}; fs.writeFileSync(`${process.env.HOME}/.istara/config.json`, JSON.stringify(cfg));'",
+    "exec node index.mjs --heartbeat-interval \"${ISTARA_RELAY_HEARTBEAT_INTERVAL:-10}\"",
+  ].join(" && ");
+  logger.action("sandbox.relay.start", {
+    donor: summarizeDonorProfile(donor),
+    container_name: containerName,
+    connection_string_present: Boolean(connectionString),
+    connection_string_rewritten_for_container: Boolean(relayConnection.rewritten),
+    rewrite_evidence: relayConnection.rewritten
+      ? {
+          before: relayConnection.before,
+          after: relayConnection.after,
+        }
+      : null,
+  });
+  const run = runCommand(`docker-run-relay-client-${donor.id}`, "docker", [
+    "run",
+    "-d",
+    "--name",
+    containerName,
+    ...dockerHostAccessArgs(),
+    "-e",
+    "ISTARA_CONNECTION_STRING",
+    "-e",
+    "ISTARA_RELAY_LLM_PROVIDER",
+    "-e",
+    "ISTARA_RELAY_LLM_HOST",
+    "-e",
+    "ISTARA_RELAY_LLM_API_KEY",
+    "-e",
+    "ISTARA_RELAY_HEARTBEAT_INTERVAL",
+    "istara-real-user-benchmark-relay",
+    "sh",
+    "-lc",
+    relayBootstrapScript,
+  ], {
+    env: {
+      ISTARA_CONNECTION_STRING: relayConnection.connectionString,
+      ISTARA_RELAY_LLM_PROVIDER: donor.provider,
+      ISTARA_RELAY_LLM_HOST: donor.host,
+      ISTARA_RELAY_LLM_API_KEY: donor.apiKey,
+      ISTARA_RELAY_HEARTBEAT_INTERVAL: process.env.ISTARA_BENCHMARK_RELAY_HEARTBEAT_INTERVAL || "10",
+    },
+    timeoutMs: 2 * 60 * 1000,
+  });
+  if (run.status === 0) {
+    sandbox.relayStarted = true;
+    relayClientContainers.push(containerName);
+    sandbox.relayStartedCount += 1;
+  }
+  if (run.status !== 0) {
+    blockers.push(`Relay/client sandbox did not start successfully for donor ${donor.id}.`);
+    logger.issue({
+      area: "client-install",
+      severity: "medium",
+      title: "Relay client sandbox failed to start",
+      detail: run.stderr || run.error?.message || "docker run returned non-zero status",
+    });
+  }
+}
+
+function startInviteClientSandbox(connectionString, index = 0) {
+  if (!startClientSandboxes || !connectionString || mode === "plan-only") {
+    logger.action("sandbox.invite_client.skip", {
+      index,
+      hasConnectionString: Boolean(connectionString),
+      startClientSandboxes,
+      mode,
+    });
+    return;
+  }
+  const daemon = ensureClientDockerDaemon("invite-client");
+  if (!daemon.ok) return;
+  sandbox.clientAttempted = true;
+  const script = `
+const decodePayload = (connectionString) => {
+  const body = connectionString.replace(/^rcl_/, "");
+  const payload = body.split(".")[0] || "";
+  const padded = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), "=");
+  return JSON.parse(Buffer.from(padded.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8"));
+};
+const post = async (serverUrl, path, body, headers = {}) => {
+  const response = await fetch(serverUrl + path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let data = text;
+  try { data = text ? JSON.parse(text) : {}; } catch {}
+  if (!response.ok) throw new Error(path + " " + response.status + " " + String(text).slice(0, 300));
+  return data;
+};
+const main = async () => {
+  const connectionString = process.env.ISTARA_CONNECTION_STRING || "";
+  const payload = decodePayload(connectionString);
+  const serverUrl = (process.env.ISTARA_CLIENT_SERVER_URL || payload.server_url || "").replace(/\\/$/, "");
+  const networkAccessToken = process.env.ISTARA_CLIENT_NETWORK_ACCESS_TOKEN || "";
+  const networkHeaders = networkAccessToken ? { "X-Access-Token": networkAccessToken } : {};
+  const username = process.env.ISTARA_CLIENT_USERNAME || "maya-client";
+  const password = process.env.ISTARA_CLIENT_PASSWORD || "IstaraBenchmarkClient123!";
+  const email = process.env.ISTARA_CLIENT_EMAIL || username + "@benchmark.istara.local";
+  const validation = await post(serverUrl, "/api/connections/validate", { connection_string: connectionString }, networkHeaders);
+  if (!validation.valid) throw new Error("Connection string validation failed: " + JSON.stringify(validation));
+  const redemption = await post(serverUrl, "/api/connections/redeem", {
+    connection_string: connectionString,
+    username,
+    password,
+    email,
+    display_name: "Maya Rodrigues Client Sandbox",
+  }, networkHeaders);
+  const meResponse = await fetch(serverUrl + "/api/auth/me", {
+    headers: { Authorization: "Bearer " + redemption.token, ...networkHeaders },
+  });
+  const meText = await meResponse.text();
+  let me = meText;
+  try { me = meText ? JSON.parse(meText) : {}; } catch {}
+  if (!meResponse.ok) throw new Error("/api/auth/me " + meResponse.status + " " + String(meText).slice(0, 300));
+  console.log(JSON.stringify({
+    ok: true,
+    server_url: serverUrl,
+    token_type: validation.token_type,
+    username,
+    user_id: redemption.user && redemption.user.id,
+    role: redemption.user && redemption.user.role,
+    me_id: me.id,
+    me_role: me.role,
+  }));
+};
+main().catch((error) => {
+  console.error(JSON.stringify({ ok: false, error: error.message }));
+  process.exit(1);
+});
+`;
+  const clientUsername = `maya-client-${index + 1}-${runId.replace(/[^a-z0-9]+/gi, "-").slice(0, 26)}`;
+  const result = runCommand(`docker-run-user-invite-client-${index + 1}`, "docker", [
+    "run",
+    "--rm",
+    ...dockerHostAccessArgs(),
+    "-e",
+    "ISTARA_CONNECTION_STRING",
+    "-e",
+    "ISTARA_CLIENT_SERVER_URL",
+    "-e",
+    "ISTARA_CLIENT_USERNAME",
+    "-e",
+    "ISTARA_CLIENT_PASSWORD",
+    "-e",
+    "ISTARA_CLIENT_EMAIL",
+    "-e",
+    "ISTARA_CLIENT_NETWORK_ACCESS_TOKEN",
+    "node:24-slim",
+    "node",
+    "-e",
+    script,
+  ], {
+    env: {
+      ISTARA_CONNECTION_STRING: connectionString,
+      ISTARA_CLIENT_SERVER_URL: process.env.ISTARA_BENCHMARK_CLIENT_SERVER_URL || containerReachableUrl(apiBase),
+      ISTARA_CLIENT_USERNAME: clientUsername,
+      ISTARA_CLIENT_PASSWORD: process.env.ISTARA_BENCHMARK_CLIENT_PASSWORD || "IstaraBenchmarkClient123!",
+      ISTARA_CLIENT_EMAIL: `${clientUsername}@benchmark.istara.local`,
+      ISTARA_CLIENT_NETWORK_ACCESS_TOKEN: benchmarkNetworkToken,
+    },
+    timeoutMs: 3 * 60 * 1000,
+  });
+  sandbox.clientStarted = sandbox.clientStarted || result.status === 0;
+  if (result.status === 0) sandbox.researcherStartedCount += 1;
+  let parsed = null;
+  const lines = String(result.stdout || "").trim().split(/\r?\n/).filter(Boolean);
+  try {
+    parsed = lines.length ? JSON.parse(lines.at(-1)) : null;
+  } catch {}
+  logger.writeJson("connection-client-results.json", {
+    attempted: true,
+    index,
+    ok: result.status === 0,
+    result: parsed,
+    stderr_preview: String(result.stderr || "").slice(-1000),
+  });
+  if (result.status !== 0) {
+    blockers.push("User invite client sandbox did not redeem the connection string successfully.");
+    logger.issue({
+      area: "client-install",
+      severity: "high",
+      title: "User invite client sandbox failed",
+      detail: parsed?.error || result.stderr || result.error?.message || "docker run returned non-zero status",
+    });
+  }
+  return {
+    ok: result.status === 0,
+    username: clientUsername,
+    password: process.env.ISTARA_BENCHMARK_CLIENT_PASSWORD || "IstaraBenchmarkClient123!",
+    email: `${clientUsername}@benchmark.istara.local`,
+    parsed,
+  };
+}
+
+function cleanupRelayClientSandboxes() {
+  if (keepClientContainers || relayClientContainers.length === 0) return;
+  for (const containerName of relayClientContainers) {
+    runCommand(`docker-logs-${containerName}`, "docker", ["logs", containerName], {
+      timeoutMs: 30 * 1000,
+    });
+    runCommand(`docker-rm-${containerName}`, "docker", ["rm", "-f", containerName], {
+      timeoutMs: 30 * 1000,
+    });
+  }
+}
+
+function preflightRelayLlmFromContainer(donorProfile = donorProfiles[0]) {
+  const donor = donorProfile || donorProfiles[0];
+  if (!requireComputeDonation || !startClientSandboxes || mode === "plan-only") {
+    logger.action("compute.preflight.skip", {
+      donor_id: donor?.id || "donor-1",
+      requireComputeDonation,
+      startClientSandboxes,
+      mode,
+    });
+    return { skipped: true };
+  }
+  if (!donor?.enabled) {
+    const preflight = {
+      attempted: false,
+      ok: false,
+      donor: summarizeDonorProfile(donor),
+      reason: donor?.blockedReason || "donor profile disabled",
+    };
+    logger.writeJson(`relay-llm-preflight-${donor?.id || "donor"}.json`, preflight);
+    logger.action("compute.preflight.profile_skip", preflight);
+    if (donor?.required) {
+      blockers.push(`Required compute donor ${donor.id} has no runnable LLM endpoint.`);
+      logger.issue({
+        area: "compute-donation",
+        severity: "critical",
+        title: "Required compute donor has no LLM endpoint",
+        detail: `Donor ${donor.id}: ${donor.blockedReason || "missing host"}. Provide a provisioned LM Studio/OpenAI-compatible endpoint instead of asking the benchmark to download or install a model.`,
+      });
+    }
+    return preflight;
+  }
+  const daemon = ensureClientDockerDaemon(`relay-preflight-${donor.id}`);
+  if (!daemon.ok) return { ok: false, skipped: true };
+  const script = `
+const provider = (process.env.ISTARA_RELAY_LLM_PROVIDER || "lmstudio").toLowerCase();
+const host = (process.env.ISTARA_RELAY_LLM_HOST || "").replace(/\\/+$/, "");
+const apiKey = process.env.ISTARA_RELAY_LLM_API_KEY || "";
+const configuredModel = process.env.ISTARA_RELAY_LLM_MODEL || "";
+const headers = { "Content-Type": "application/json" };
+if (apiKey) headers.Authorization = "Bearer " + apiKey;
+let loadAttempted = false;
+let loadOk = false;
+let loadError = "";
+let modelCount = 0;
+let configuredModelListed = null;
+let selectedModelIdLength = 0;
+let modelListSource = "";
+const redact = (value) => {
+  let output = String(value || "");
+  for (const secret of [host, apiKey, configuredModel].filter(Boolean)) {
+    output = output.split(secret).join("[redacted]");
+  }
+  return output;
+};
+const openAIUrl = (suffix) => {
+  const clean = suffix.replace(/^\\/+/, "");
+  const parsed = new URL(host);
+  const basePath = parsed.pathname.replace(/\\/+$/, "");
+  if (basePath.endsWith("/v1") || basePath.endsWith("/openai")) return host + "/" + clean;
+  return host + "/v1/" + clean;
+};
+const fetchJson = async (url, options = {}) => {
+  const res = await fetch(url, { ...options, headers: { ...headers, ...(options.headers || {}) }, signal: AbortSignal.timeout(30000) });
+  const text = await res.text();
+  let data = text;
+  try { data = text ? JSON.parse(text) : {}; } catch {}
+  if (!res.ok) throw new Error(String(res.status) + " " + String(text).slice(0, 240));
+  return data;
+};
+const modelId = (item) => typeof item === "string" ? item : (item && (item.id || item.name || item.model || item.path)) || "";
+const loadConfiguredModel = async (model) => {
+  if (provider !== "lmstudio" || !model || model === "default") return false;
+  loadAttempted = true;
+  try {
+    await fetchJson(host + "/api/v1/models/load", {
+      method: "POST",
+      body: JSON.stringify({ model, echo_load_config: true })
+    });
+    loadOk = true;
+    return true;
+  } catch (error) {
+    loadError = redact(error.message);
+    return false;
+  }
+};
+const tinyChat = async (model) => fetchJson(openAIUrl("chat/completions"), {
+  method: "POST",
+  body: JSON.stringify({
+    model,
+    messages: [{ role: "user", content: "Reply with the exact marker BENCHMARK_DONATION_READY." }],
+    temperature: 0,
+    max_tokens: 32,
+    stream: false
+  })
+});
+const main = async () => {
+  if (!host) throw new Error("No relay LLM host configured");
+  let modelData;
+  try {
+    modelData = provider === "lmstudio"
+      ? await fetchJson(host + "/api/v1/models")
+      : await fetchJson(openAIUrl("models"));
+    modelListSource = provider === "lmstudio" ? "lmstudio-native" : "openai-compatible";
+  } catch (firstError) {
+    modelData = await fetchJson(openAIUrl("models"));
+    modelListSource = "openai-compatible";
+  }
+  let rawModels = Array.isArray(modelData?.data) ? modelData.data : Array.isArray(modelData?.models) ? modelData.models : [];
+  let models = rawModels.map(modelId).filter(Boolean);
+  if (provider === "lmstudio" && models.length === 0) {
+    try {
+      modelData = await fetchJson(openAIUrl("models"));
+      rawModels = Array.isArray(modelData?.data) ? modelData.data : Array.isArray(modelData?.models) ? modelData.models : [];
+      models = rawModels.map(modelId).filter(Boolean);
+      modelListSource = "openai-compatible";
+    } catch {}
+  }
+  modelCount = models.length;
+  configuredModelListed = configuredModel && configuredModel !== "default" ? models.includes(configuredModel) : null;
+  const model = configuredModel && configuredModel !== "default" ? configuredModel : models[0];
+  selectedModelIdLength = model ? model.length : 0;
+  if (!model) throw new Error("No chat model available from configured relay LLM target");
+  let completion;
+  try {
+    completion = await tinyChat(model);
+  } catch (chatError) {
+    if (
+      provider === "lmstudio"
+      && configuredModel
+      && configuredModel !== "default"
+      && /no models loaded|not loaded|load/i.test(chatError.message)
+    ) {
+      await loadConfiguredModel(configuredModel);
+      completion = await tinyChat(model);
+    } else {
+      throw chatError;
+    }
+  }
+  const content = completion?.choices?.[0]?.message?.content || "";
+  console.log(JSON.stringify({
+    ok: true,
+    provider,
+    model_count: modelCount,
+    configured_model_listed: configuredModelListed,
+    model_list_source: modelListSource,
+    selected_model_source: configuredModel && configuredModel !== "default" ? "configured" : "first-listed",
+    selected_model_id_length: selectedModelIdLength,
+    load_attempted: loadAttempted,
+    load_ok: loadOk,
+    load_error_present: Boolean(loadError),
+    load_error_preview: loadError.slice(0, 240),
+    chat_chars: content.length,
+    contains_marker: /BENCHMARK_DONATION_READY/i.test(content)
+  }));
+};
+main().catch((error) => {
+  console.error(JSON.stringify({ ok: false, error: redact(error.message), model_count: modelCount, configured_model_listed: configuredModelListed, model_list_source: modelListSource, selected_model_source: configuredModel && configuredModel !== "default" ? "configured" : "first-listed", selected_model_id_length: selectedModelIdLength, load_attempted: loadAttempted, load_ok: loadOk, load_error_present: Boolean(loadError), load_error_preview: loadError.slice(0, 240) }));
+  process.exit(1);
+});
+`;
+  const result = runCommand(`docker-run-relay-llm-preflight-${donor.id}`, "docker", [
+    "run",
+    "--rm",
+    ...dockerHostAccessArgs(),
+    "-e",
+    "ISTARA_RELAY_LLM_PROVIDER",
+    "-e",
+    "ISTARA_RELAY_LLM_HOST",
+    "-e",
+    "ISTARA_RELAY_LLM_API_KEY",
+    "-e",
+    "ISTARA_RELAY_LLM_MODEL",
+    "node:24-slim",
+    "node",
+    "-e",
+    script,
+  ], {
+    env: {
+      ISTARA_RELAY_LLM_PROVIDER: donor.provider,
+      ISTARA_RELAY_LLM_HOST: donor.host,
+      ISTARA_RELAY_LLM_API_KEY: donor.apiKey,
+      ISTARA_RELAY_LLM_MODEL: donor.model,
+    },
+    timeoutMs: 2 * 60 * 1000,
+  });
+  let parsed = null;
+  const lines = `${result.stdout || ""}\n${result.stderr || ""}`.trim().split(/\r?\n/).filter(Boolean);
+  for (const line of lines.slice().reverse()) {
+    try {
+      parsed = JSON.parse(line);
+      break;
+    } catch {}
+  }
+  const preflight = {
+    attempted: true,
+    donor: summarizeDonorProfile(donor),
+    ok: result.status === 0 && parsed?.ok === true,
+    result: parsed,
+    stderr_preview: sanitizeLogText(result.stderr || "").slice(-1000),
+    relay_host: hostSummary(donor.host),
+    relay_host_source: donor.hostSource,
+    relay_provider: donor.provider,
+    relay_provider_source: donor.providerSource,
+    relay_host_localhost_translated_for_container: donor.hostRaw !== donor.hostForContainer,
+    relay_host_openai_path_stripped_for_native_lmstudio: donor.hostNormalized,
+    api_key_configured: Boolean(donor.apiKey),
+    api_key_source: donor.apiKeySource,
+    model_configured: Boolean(donor.model && donor.model !== "default"),
+    model_source: donor.modelSource,
+  };
+  logger.writeJson(`relay-llm-preflight-${donor.id}.json`, preflight);
+  if (donor.index === 1) logger.writeJson("relay-llm-preflight.json", preflight);
+  logger.action("compute.preflight.result", preflight);
+  if (!preflight.ok) {
+    blockers.push(`Configured relay target failed the container preflight for donor ${donor.id}.`);
+    logger.issue({
+      area: "compute-donation",
+      severity: "critical",
+      title: "Relay LLM target failed container preflight",
+      detail: parsed?.error || sanitizeLogText(result.stderr || "") || "The client container could not list models and complete a tiny chat request against the configured LM Studio target.",
+    });
+  }
+  return preflight;
+}
+
+async function waitForRelayRegistrations(api, expectedCount = 1, timeoutMs = 90000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastStats = null;
+  while (Date.now() < deadline) {
+    try {
+      lastStats = await api.get("/api/compute/stats", { timeoutMs: 15000 });
+      const nodes = Array.isArray(lastStats.nodes) ? lastStats.nodes : [];
+      const relayNodes = nodes.filter((node) => ["relay", "browser"].includes(node.source));
+      if (relayNodes.length >= expectedCount) {
+        const evidence = relayNodes.map(summarizeRelayNode);
+        logger.action("compute.relay.registered", {
+          expected_count: expectedCount,
+          registered_count: evidence.length,
+          nodes: evidence,
+        });
+        return { ok: true, nodes: evidence, node: evidence[0], stats: summarizeComputeStats(lastStats) };
+      }
+      logger.action("compute.relay.poll", {
+        total_nodes: lastStats.total_nodes,
+        alive_nodes: lastStats.alive_nodes,
+        expected_count: expectedCount,
+        relay_nodes: relayNodes.length,
+      });
+    } catch (error) {
+      logger.action("compute.relay.poll_error", { error: error.message });
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 3000));
+  }
+  const nodes = Array.isArray(lastStats?.nodes) ? lastStats.nodes.map(summarizeRelayNode) : [];
+  return { ok: false, expected_count: expectedCount, nodes, stats: summarizeComputeStats(lastStats) };
+}
+
+async function waitForRelayRegistration(api, timeoutMs = 90000) {
+  return waitForRelayRegistrations(api, 1, timeoutMs);
+}
+
+function summarizeRelayNode(node) {
+  const capabilities = node.model_capabilities || {};
+  return {
+    node_id: node.node_id || "",
+    source: node.source || "",
+    provider_type: node.provider_type || "",
+    state: node.state || "",
+    serving_state: node.serving_state || "",
+    health_error_present: Boolean(node.health_error),
+    alive: Boolean(node.alive ?? node.is_healthy),
+    loaded_model_count: Array.isArray(node.loaded_models) ? node.loaded_models.length : 0,
+    capability_model_count: Object.keys(capabilities).length,
+    active_requests: node.active_requests || 0,
+    score: node.score || 0,
+  };
+}
+
+function summarizeComputeStats(stats) {
+  const nodes = Array.isArray(stats?.nodes) ? stats.nodes : [];
+  return {
+    total_nodes: stats?.total_nodes,
+    alive_nodes: stats?.alive_nodes,
+    available_model_count: Array.isArray(stats?.available_models) ? stats.available_models.length : 0,
+    request_slots_total: stats?.request_slots_total,
+    request_slots_used: stats?.request_slots_used,
+    request_slots_available: stats?.request_slots_available,
+    nodes: nodes.map(summarizeRelayNode),
+  };
+}
+
+function captureBackendLogs(label, since = "5m") {
+  if (!startSandbox || skipSandbox) return { stdout: "", stderr: "", status: 0 };
+  return runCommand(`docker-logs-backend-${label}`, "docker", [
+    "logs",
+    "--since",
+    since,
+    "istara-benchmark-backend",
+  ], {
+    timeoutMs: 30 * 1000,
+  });
+}
+
+async function verifyComputeDonation(api, projectId, { activeDonorProfiles = donorProfiles } = {}) {
+  if (!requireComputeDonation) {
+    logger.action("compute.donation.verify.skip", { requireComputeDonation });
+    return { skipped: true };
+  }
+  const expectedRelayCount = Math.max(1, activeDonorProfiles.filter((profile) => profile.enabled).length);
+  const registration = await waitForRelayRegistrations(api, expectedRelayCount);
+  if (!registration.ok) {
+    blockers.push(`Compute donation relay registration incomplete: ${registration.nodes?.length || 0}/${expectedRelayCount} relay nodes observed.`);
+    logger.issue({
+      area: "compute-donation",
+      severity: "critical",
+      title: "Compute donation relay did not register",
+      detail: "The benchmark generated or consumed compute donation strings and started relay clients, but /api/compute/stats did not show the expected relay/browser node count.",
+    });
+    logger.writeJson("compute-donation-results.json", {
+      expected_relay_count: expectedRelayCount,
+      donor_profiles: activeDonorProfiles.map(summarizeDonorProfile),
+      registration,
+    });
+    return { ok: false, registration };
+  }
+
+  const startedAt = Date.now();
+  let chat = null;
+  let chatError = "";
+  try {
+    chat = await api.sendChat({
+      projectId,
+      message: "Benchmark technical probe: answer with the phrase BENCHMARK_DONATION_OK and one short sentence about donated compute being connected.",
+      maxHistory: 0,
+      timeoutMs: chatTimeoutMs,
+    });
+  } catch (error) {
+    chatError = error.message;
+  }
+  const backendLogs = captureBackendLogs("compute-donation-probe", "5m");
+  const routeUsedRelay = /routing (stream|chat) to Relay:/i.test(`${backendLogs.stdout}\n${backendLogs.stderr}`);
+  const routeAttemptedRelay = routeUsedRelay || /(stream|chat) failed on Relay:/i.test(`${backendLogs.stdout}\n${backendLogs.stderr}`);
+  const responseChars = chat?.content?.trim().length || 0;
+  const statsNodes = Array.isArray(registration.stats?.nodes) ? registration.stats.nodes : [];
+  const aliveRelayNodes = statsNodes.filter((node) => ["relay", "browser"].includes(node.source) && node.alive);
+  const aliveDirectNodes = statsNodes.filter((node) => !["relay", "browser"].includes(node.source) && node.alive);
+  const forcedRelayTopology = forceDonatedChat && aliveRelayNodes.length > 0 && aliveDirectNodes.length === 0;
+  const routeVerifiedBy = routeUsedRelay
+    ? "backend-route-log"
+    : forcedRelayTopology
+      ? "forced-topology-only-alive-node"
+      : "unverified";
+  const ok = !chatError && responseChars > 0 && (routeUsedRelay || forcedRelayTopology);
+  const result = {
+    ok,
+    duration_ms: Date.now() - startedAt,
+    expected_relay_count: expectedRelayCount,
+    donor_profiles: activeDonorProfiles.map(summarizeDonorProfile),
+    registration,
+    donated_compute_chat_verified: ok,
+    route_used_relay: routeUsedRelay,
+    route_attempted_relay: routeAttemptedRelay,
+    route_verified_by: routeVerifiedBy,
+    route_evidence_detail: routeUsedRelay
+      ? "Backend logs explicitly reported Relay routing."
+      : forcedRelayTopology
+        ? "The benchmark forced direct server providers unreachable and /api/compute/stats showed the relay as the only alive compute node."
+        : "Relay routing could not be proved from backend logs or forced topology.",
+    forced_relay_topology: forcedRelayTopology,
+    alive_relay_node_count: aliveRelayNodes.length,
+    alive_direct_node_count: aliveDirectNodes.length,
+    multi_donor_registered: expectedRelayCount > 1 && (registration.nodes?.length || 0) >= expectedRelayCount,
+    chat_error: chatError,
+    response_chars: responseChars,
+    response_preview: (chat?.content || "").slice(0, 600),
+    event_count: chat?.events?.length || 0,
+  };
+  logger.writeJson("compute-donation-results.json", result);
+  logger.action("compute.donation.verify.result", result);
+  if (!ok) {
+    blockers.push("Compute donation did not produce a verified relay-routed chat response.");
+    logger.issue({
+      area: "compute-donation",
+      severity: "critical",
+      title: "Donated compute chat was not verified",
+      detail: chatError || (routeAttemptedRelay ? "Relay route was attempted but did not return user-visible chat output." : "Neither backend route logs nor forced-topology evidence proved relay-routed chat."),
+    });
+  } else {
+    featureResults.computeDonation = true;
+    featureResults.multiDonorCompute = expectedRelayCount > 1 && (registration.nodes?.length || 0) >= expectedRelayCount;
+    featureResults.liveChat = true;
+  }
+  return result;
+}
+
+async function createProject(api) {
+  const body = {
+    name: `[RU-BENCH] ${PROJECT_CONTEXT.name} ${runId}`,
+    description: `${PROJECT_CONTEXT.product}. Synthetic long-form benchmark project.`,
+    phase: "discover",
+    company_context: `${PROJECT_CONTEXT.company}: ${PROJECT_CONTEXT.audience}.`,
+    project_context: PROJECT_CONTEXT.researchQuestions.join("\n"),
+    guardrails: PROJECT_CONTEXT.guardrails.join("\n"),
+  };
+  const project = await api.post("/api/projects", body);
+  logger.action("project.created", { project_id: project.id, name: project.name });
+  return project;
+}
+
+async function grantResearcherProjectAccess(api, projectId, inviteResult) {
+  const userId = inviteResult?.parsed?.user_id || inviteResult?.parsed?.me_id || "";
+  if (!userId) {
+    logger.action("researcher.access.skip", { reason: "no-user-id", invite_ok: Boolean(inviteResult?.ok) });
+    return false;
+  }
+  try {
+    await api.post(`/api/projects/${projectId}/members`, {
+      user_id: userId,
+      role: "researcher",
+    });
+    logger.action("researcher.access.granted", { project_id: projectId, user_id: userId, role: "researcher" });
+    return true;
+  } catch (error) {
+    if (/409/.test(error.message)) {
+      logger.action("researcher.access.already_member", { project_id: projectId, user_id: userId });
+      return true;
+    }
+    logger.issue({
+      area: "auth",
+      severity: "high",
+      title: "Could not grant researcher project access",
+      detail: error.message,
+    });
+    return false;
+  }
+}
+
+async function linkProjectFolder(api, projectId, corpusDir) {
+  const folderPath = startSandbox && !skipSandbox ? `/benchmark-results/runs/${runId}/corpus` : corpusDir;
+  try {
+    const linked = await api.post(`/api/projects/${projectId}/link-folder`, { folder_path: folderPath });
+    logger.action("project.folder_linked", { project_id: projectId, folder_path: folderPath, result: linked });
+    return true;
+  } catch (error) {
+    logger.issue({
+      area: "project-context",
+      severity: "low",
+      title: "Could not link generated corpus folder",
+      detail: error.message,
+    });
+    return false;
+  }
+}
+
+async function uploadCorpus(api, projectId, manifest, limit) {
+  const uploaded = [];
+  for (const item of manifest.slice(0, limit)) {
+    try {
+      const result = await api.uploadFile(projectId, item.path, item.file_name);
+      uploaded.push({ ...item, result });
+      logger.action("corpus.uploaded", {
+        file_name: item.file_name,
+        document_id: result.id || result.file_id || result.document_id || "",
+      });
+    } catch (error) {
+      logger.issue({
+        area: "upload",
+        severity: "medium",
+        title: `Upload failed: ${item.file_name}`,
+        detail: error.message,
+      });
+    }
+  }
+  const resolved = await resolveUploadedDocuments(api, projectId, uploaded);
+  logger.writeJson("uploaded-document-manifest.json", resolved);
+  return resolved;
+}
+
+async function resolveUploadedDocuments(api, projectId, uploaded) {
+  try {
+    const listing = await api.get(`/api/files/${projectId}`);
+    const files = Array.isArray(listing.files) ? listing.files : [];
+    const byDisplayName = new Map(files.map((file) => [file.display_name, file]));
+    const byStoredName = new Map(files.map((file) => [file.name, file]));
+    return uploaded.map((item) => {
+      const match = byDisplayName.get(item.file_name) || byStoredName.get(item.result?.saved_as);
+      return {
+        ...item,
+        document_id: match?.document_id || item.result?.doc_id || item.result?.document_id || "",
+        document_status: match?.document_status || "",
+      };
+    });
+  } catch (error) {
+    logger.issue({
+      area: "upload",
+      severity: "medium",
+      title: "Could not resolve uploaded files to document IDs",
+      detail: error.message,
+    });
+    return uploaded;
+  }
+}
+
+function uploadedDocumentIds(uploaded) {
+  return uploaded
+    .map((item) => item.document_id || item.result?.doc_id || item.result?.document_id)
+    .filter(Boolean);
+}
+
+async function createConnectionStrings(api, { donorProfilesForRun = donorProfiles, researcherCount = runtimeResearcherCount } = {}) {
+  const output = {
+    userInvites: [],
+    computeDonations: [],
+  };
+  const defaultConnectionServerUrl = startSandbox && !skipSandbox ? containerReachableUrl(apiBase) : apiBase;
+  const connectionServerUrl = (process.env.ISTARA_BENCHMARK_CONNECTION_SERVER_URL || defaultConnectionServerUrl).replace(/\/$/, "");
+  const connectionWsUrl = (process.env.ISTARA_BENCHMARK_CONNECTION_WS_URL || `${connectionServerUrl.replace(/^http/, "ws")}/ws/relay`).replace(/\/$/, "");
+  for (let index = 0; index < researcherCount; index += 1) {
+    try {
+      const userInvite = await api.post("/api/connections/generate", {
+        server_url: connectionServerUrl,
+        ws_url: connectionWsUrl,
+        label: `Real user benchmark invite ${index + 1} ${runId}`,
+        role: "researcher",
+        expires_hours: 24,
+      });
+      output.userInvites.push(userInvite);
+      if (index === 0) output.userInvite = userInvite;
+      logger.action("connection.user_invite.generated", {
+        index,
+        id: userInvite.id,
+        preview: `${String(userInvite.connection_string).slice(0, 18)}...`,
+      });
+    } catch (error) {
+      blockers.push(`User invite connection string generation failed for researcher ${index + 1}.`);
+      logger.issue({
+        area: "connection-string",
+        severity: "high",
+        title: "User invite connection string generation failed",
+        detail: error.message,
+      });
+    }
+  }
+  for (const donor of donorProfilesForRun.filter((profile) => profile.required)) {
+    try {
+      const computeDonation = await api.post("/api/connections/compute-donation/generate", {
+        server_url: connectionServerUrl,
+        ws_url: connectionWsUrl,
+        label: `Real user benchmark relay ${donor.id} ${runId}`,
+        expires_hours: 24,
+      });
+      output.computeDonations.push({ ...computeDonation, donor_id: donor.id });
+      if (!output.computeDonation) output.computeDonation = computeDonation;
+      logger.action("connection.compute.generated", {
+        donor_id: donor.id,
+        id: computeDonation.id,
+        preview: `${String(computeDonation.connection_string).slice(0, 18)}...`,
+      });
+    } catch (error) {
+      blockers.push(`Compute donation connection string generation failed for donor ${donor.id}.`);
+      logger.issue({
+        area: "connection-string",
+        severity: "high",
+        title: "Compute donation connection string generation failed",
+        detail: error.message,
+      });
+    }
+  }
+  logger.writeJson("connection-string-results.json", {
+    user_invite_generated: Boolean(output.userInvite?.connection_string),
+    compute_donation_generated: Boolean(output.computeDonation?.connection_string),
+    user_invite_count: output.userInvites.length,
+    compute_donation_count: output.computeDonations.length,
+    user_invite_id: output.userInvite?.id || "",
+    compute_donation_id: output.computeDonation?.id || "",
+    donor_profiles: donorProfilesForRun.map(summarizeDonorProfile),
+  });
+  return output;
+}
+
+function connectionListFromPlan(config, keys) {
+  if (!config || typeof config !== "object") return [];
+  for (const key of keys) {
+    if (config[key]) {
+      return asArray(config[key]).map(String).map((item) => item.trim()).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function loadConnectionStringOverrides() {
+  const fileConfig = readJsonConfigFile(
+    process.env.ISTARA_BENCHMARK_CONNECTION_STRINGS_FILE,
+    "ISTARA_BENCHMARK_CONNECTION_STRINGS_FILE",
+  );
+  const computeFromFile = connectionListFromPlan(fileConfig, [
+    "compute_donations",
+    "computeDonations",
+    "compute_connection_strings",
+    "computeConnectionStrings",
+    "donor_connection_strings",
+    "donorConnectionStrings",
+  ]);
+  const userFromFile = connectionListFromPlan(fileConfig, [
+    "user_invites",
+    "userInvites",
+    "user_invite_connection_strings",
+    "userInviteConnectionStrings",
+    "researcher_invites",
+    "researcherInvites",
+  ]);
+  const computeFromEnv = [
+    ...parseConnectionStringList(process.env.ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRINGS),
+    ...parseConnectionStringList(process.env.ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRING),
+  ];
+  const userFromEnv = [
+    ...parseConnectionStringList(process.env.ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRINGS),
+    ...parseConnectionStringList(process.env.ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRING),
+  ];
+  const computeFromProfiles = donorProfiles.map((profile) => profile.connectionString).filter(Boolean);
+  return {
+    computeDonations: [...computeFromFile, ...computeFromEnv, ...computeFromProfiles],
+    userInvites: [...userFromFile, ...userFromEnv],
+    sources: {
+      file: Boolean(fileConfig),
+      compute_env: computeFromEnv.length,
+      user_env: userFromEnv.length,
+      donor_profiles: computeFromProfiles.length,
+    },
+  };
+}
+
+async function maybePromptForConnectionOverrides(overrides) {
+  if (!boolEnv("ISTARA_BENCHMARK_INTERACTIVE_CONNECTION_STRINGS", false)) return overrides;
+  if (!process.stdin.isTTY) {
+    blockers.push("Interactive connection string mode was requested, but stdin is not a TTY.");
+    logger.issue({
+      area: "connection-string",
+      severity: "high",
+      title: "Interactive connection prompt unavailable",
+      detail: "Set ISTARA_BENCHMARK_COMPUTE_CONNECTION_STRINGS and ISTARA_BENCHMARK_USER_INVITE_CONNECTION_STRINGS, or run the benchmark from an interactive terminal.",
+    });
+    return overrides;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const currentDonorCount = donorProfiles.filter((profile) => profile.required).length;
+    const donorAnswer = await rl.question(`How many compute donor containers should this run start? [${currentDonorCount}] `);
+    const donorCount = Number.parseInt(donorAnswer.trim(), 10);
+    if (Number.isFinite(donorCount) && donorCount > 0 && donorCount !== currentDonorCount) {
+      donorProfiles = buildDonorProfiles({ donorCountOverride: donorCount });
+      sandbox.relayExpectedCount = donorProfiles.filter((profile) => profile.required).length;
+      logger.action("connection.interactive.donor_count", {
+        requested_count: donorCount,
+        donor_profiles: donorProfiles.map(summarizeDonorProfile),
+      });
+    }
+    const researcherAnswer = await rl.question(`How many researcher invite/client containers should this run start? [${runtimeResearcherCount}] `);
+    const researcherCount = Number.parseInt(researcherAnswer.trim(), 10);
+    if (Number.isFinite(researcherCount) && researcherCount > 0) {
+      runtimeResearcherCount = researcherCount;
+      sandbox.researcherExpectedCount = runtimeResearcherCount;
+    }
+    const requiredDonors = donorProfiles.filter((profile) => profile.required);
+    const computeDonations = [...overrides.computeDonations];
+    for (let index = computeDonations.length; index < requiredDonors.length; index += 1) {
+      const answer = await rl.question(`Paste compute donation connection string for ${requiredDonors[index].id}, or leave blank to generate through the API when possible: `);
+      if (answer.trim()) computeDonations.push(answer.trim());
+    }
+    const userInvites = [...overrides.userInvites];
+    for (let index = userInvites.length; index < runtimeResearcherCount; index += 1) {
+      const answer = await rl.question(`Paste researcher invite connection string ${index + 1}, or leave blank to generate through the API when possible: `);
+      if (answer.trim()) userInvites.push(answer.trim());
+    }
+    return {
+      ...overrides,
+      computeDonations,
+      userInvites,
+      sources: {
+        ...overrides.sources,
+        interactive: true,
+      },
+    };
+  } finally {
+    rl.close();
+  }
+}
+
+function materializeConnectionStrings(generated, overrides) {
+  const computeOverrideStrings = overrides.computeDonations || [];
+  const userOverrideStrings = overrides.userInvites || [];
+  const output = {
+    ...generated,
+    userInvites: [],
+    computeDonations: [],
+  };
+  const generatedUserInvites = generated.userInvites || (generated.userInvite ? [generated.userInvite] : []);
+  const generatedComputeDonations = generated.computeDonations || (generated.computeDonation ? [generated.computeDonation] : []);
+  const userCount = Math.max(runtimeResearcherCount, userOverrideStrings.length, generatedUserInvites.length);
+  for (let index = 0; index < userCount; index += 1) {
+    const override = userOverrideStrings[index];
+    const generatedInvite = generatedUserInvites[index];
+    const invite = override
+      ? { connection_string: override, source: "external-override", id: `external-user-invite-${index + 1}` }
+      : generatedInvite;
+    if (invite?.connection_string) {
+      rememberConnectionStringSensitiveValues(invite.connection_string);
+      output.userInvites.push(invite);
+    }
+  }
+  output.userInvite = output.userInvites[0] || generated.userInvite;
+
+  const requiredDonors = donorProfiles.filter((profile) => profile.required);
+  for (let index = 0; index < requiredDonors.length; index += 1) {
+    const donor = requiredDonors[index];
+    const override = computeOverrideStrings[index] || donor.connectionString;
+    const generatedDonation = generatedComputeDonations[index];
+    const donation = override
+      ? { connection_string: override, source: "external-override", id: `external-compute-${donor.id}`, donor_id: donor.id }
+      : generatedDonation;
+    if (donation?.connection_string) {
+      rememberConnectionStringSensitiveValues(donation.connection_string);
+      output.computeDonations.push({ ...donation, donor_id: donor.id });
+    }
+  }
+  output.computeDonation = output.computeDonations[0] || generated.computeDonation;
+  logger.writeJson("connection-string-plan.json", {
+    external_mode: externalConnectionStringMode,
+    overrides: {
+      compute_count: computeOverrideStrings.length,
+      user_invite_count: userOverrideStrings.length,
+      sources: overrides.sources,
+    },
+    materialized: {
+      compute_count: output.computeDonations.length,
+      user_invite_count: output.userInvites.length,
+    },
+    donor_profiles: donorProfiles.map(summarizeDonorProfile),
+  });
+  logger.action("connection.plan.materialized", {
+    external_mode: externalConnectionStringMode,
+    compute_count: output.computeDonations.length,
+    user_invite_count: output.userInvites.length,
+    donor_count: requiredDonors.length,
+  });
+  return output;
+}
+
+async function runChatBenchmark(api, projectId, turns) {
+  let sessionId = null;
+  const completed = [];
+  for (const turn of turns) {
+    const started = Date.now();
+    try {
+      const response = await api.sendChat({
+        projectId,
+        message: turn.content,
+        sessionId,
+        maxHistory: 40,
+        timeoutMs: chatTimeoutMs,
+      });
+      sessionId = response.session_id || sessionId;
+      const content = response.content || "";
+      if (requireLiveChat && !content.trim()) {
+        throw new Error("Chat returned no assistant text. Live model-backed output is required for this benchmark profile.");
+      }
+      const hasCitation = /interview|survey|usability|diary|ticket|source|file/i.test(content);
+      if (hasCitation) featureResults.citedSources = true;
+      if (content.trim()) featureResults.liveChat = true;
+      completed.push({ turn: turn.turn, ok: true });
+      logger.chatTurn({
+        turn: turn.turn,
+        intent: turn.intent,
+        prompt: turn.content,
+        ok: true,
+        duration_ms: Date.now() - started,
+        response_preview: content.slice(0, 1200),
+        event_count: response.events.length,
+        session_id: sessionId,
+        quality_notes: {
+          mentions_sources: hasCitation,
+          response_chars: content.length,
+        },
+      });
+    } catch (error) {
+      logger.chatTurn({
+        turn: turn.turn,
+        intent: turn.intent,
+        prompt: turn.content,
+        ok: false,
+        duration_ms: Date.now() - started,
+        error: error.message,
+      });
+      logger.issue({
+        area: "chat",
+        severity: "high",
+        title: `Chat turn ${turn.turn} failed`,
+        detail: error.message,
+      });
+      blockers.push(`Chat benchmark stopped at turn ${turn.turn}: ${error.message}`);
+      break;
+    }
+  }
+  if (completed.length > 0) featureResults.uploadedAndQueried = true;
+  return completed.length;
+}
+
+function syntheticAgentNotes(task, { weak = false } = {}) {
+  if (weak) return "Done. Users were confused.";
+  return [
+    `Evidence summary for ${task.title}:`,
+    "Sources reviewed: interviews P01/P06/P13, carenav-survey-180.csv, usability-test-02.md, support-tickets.jsonl.",
+    `Evidence: ${task.description}`,
+    "Interpretation: the strongest pattern is that users need source freshness and role boundaries before they trust readiness automation.",
+    "Recommendation: prototype a timeline that marks required, optional, blocked, and stale tasks, with a caregiver-safe permission label.",
+    "Confidence: medium-high because interviews, survey responses, and tickets converge, but analytics needs a larger post-redesign sample.",
+  ].join("\n");
+}
+
+async function createReviewAndApproveTasks(api, projectId, taskPlan, uploaded) {
+  let approvals = 0;
+  for (const plan of taskPlan) {
+    try {
+      const task = await api.post("/api/tasks", {
+        project_id: projectId,
+        title: plan.title,
+        description: plan.description,
+        skill_name: plan.skill_name,
+        user_context: `Benchmark researcher Maya will review this. Acceptance criteria:\n${plan.acceptance.join("\n")}`,
+        input_document_ids: uploadedDocumentIds(uploaded).slice(0, 8),
+        urls: plan.title.includes("Integration") ? ["https://example.com/healthcare-coordination-benchmark"] : [],
+        instructions: plan.acceptance.join("\n"),
+        labels: plan.labels,
+        priority: plan.priority,
+      });
+      logger.taskReview({
+        task_id: task.id,
+        title: task.title,
+        action: "created",
+        outcome: "created",
+      });
+
+      if (plan.shouldReviseFirst) {
+        const weakNotes = syntheticAgentNotes(plan, { weak: true });
+        const inReview = await api.patch(`/api/tasks/${task.id}`, {
+          status: "in_review",
+          agent_notes: weakNotes,
+          progress: 1,
+          what_to_review: "Check whether this has enough evidence and source specificity.",
+        });
+        const assessment = reviewerAssessment(plan, inReview.agent_notes);
+        await api.post(`/api/tasks/${task.id}/review/request-revision`, {
+          what_to_review: assessment.revisionInstruction,
+          next_status: "in_progress",
+          reviewed_by: "Maya Rodrigues benchmark",
+          severity: "medium",
+          failure_category: "unsupported_summary",
+        });
+        logger.taskReview({
+          task_id: task.id,
+          title: task.title,
+          action: "reviewed",
+          outcome: "revision_requested",
+          issues: assessment.issues,
+          instruction: assessment.revisionInstruction,
+        });
+      }
+
+      const revised = await api.patch(`/api/tasks/${task.id}`, {
+        status: "in_review",
+        agent_notes: syntheticAgentNotes(plan),
+        progress: 1,
+        what_to_review: "Review for grounding, utility, and safety.",
+      });
+      const finalAssessment = reviewerAssessment(plan, revised.agent_notes);
+      if (!finalAssessment.approved) {
+        await api.post(`/api/tasks/${task.id}/review/request-revision`, {
+          what_to_review: finalAssessment.revisionInstruction,
+          next_status: "in_progress",
+          reviewed_by: "Maya Rodrigues benchmark",
+          severity: "high",
+          failure_category: "reviewer_quality_gate",
+        });
+        logger.taskReview({
+          task_id: task.id,
+          title: task.title,
+          action: "reviewed",
+          outcome: "revision_requested",
+          issues: finalAssessment.issues,
+          instruction: finalAssessment.revisionInstruction,
+        });
+        continue;
+      }
+
+      const approved = await api.post(`/api/tasks/${task.id}/review/approve`, {
+        reviewed_by: "Maya Rodrigues benchmark",
+        note: finalAssessment.revisionInstruction,
+      });
+      approvals += 1;
+      logger.taskReview({
+        task_id: task.id,
+        title: task.title,
+        action: "reviewed",
+        outcome: "approved",
+        review_event_id: approved.event?.id || "",
+        note: finalAssessment.revisionInstruction,
+      });
+    } catch (error) {
+      logger.issue({
+        area: "task-review",
+        severity: "high",
+        title: `Task review flow failed for ${plan.title}`,
+        detail: error.message,
+      });
+    }
+  }
+  return approvals;
+}
+
+async function exerciseLoopsAutoresearch(api, projectId) {
+  let ok = false;
+  for (const [label, fn] of [
+    ["loops overview", () => api.get("/api/loops/overview")],
+    ["loops agents", () => api.get("/api/loops/agents")],
+    ["loop schedule create", () => api.post("/api/schedules", {
+      name: `[RU-BENCH] Weekly support ticket review ${runId}`,
+      cron_expression: "0 9 * * 1",
+      project_id: projectId,
+      skill_name: "analyze-interview",
+      description: "Benchmark weekly loop for new support-ticket evidence.",
+    })],
+    ["autoresearch status", () => api.get("/api/autoresearch/status")],
+    ["autoresearch config", () => api.get("/api/autoresearch/config")],
+  ]) {
+    try {
+      const result = await fn();
+      logger.action("feature.loops_autoresearch", { label, ok: true, result: preview(result) });
+      ok = true;
+    } catch (error) {
+      logger.action("feature.loops_autoresearch", { label, ok: false, error: error.message });
+    }
+  }
+  featureResults.loops = ok;
+  return ok;
+}
+
+async function exerciseFindingsReports(api, projectId) {
+  try {
+    const nugget = await api.post("/api/findings/nuggets", {
+      project_id: projectId,
+      text: "Care coordinators need source freshness before trusting readiness automation.",
+      source: "interviews/P06-care-coordinator.md",
+      source_location: "05:42",
+      tags: ["trust", "readiness", "source-trail"],
+      phase: "discover",
+    });
+    const fact = await api.post("/api/findings/facts", {
+      project_id: projectId,
+      text: "Multiple sources converge on missing source trail as a trust blocker.",
+      nugget_ids: [nugget.id],
+      phase: "define",
+    });
+    const insight = await api.post("/api/findings/insights", {
+      project_id: projectId,
+      text: "Readiness automation is not trusted unless it exposes source and freshness.",
+      fact_ids: [fact.id],
+      phase: "define",
+      impact: "high",
+    });
+    await api.post("/api/findings/recommendations", {
+      project_id: projectId,
+      text: "Add source freshness, required/optional labels, and caregiver-safe visibility to the readiness timeline.",
+      insight_ids: [insight.id],
+      phase: "deliver",
+      priority: "high",
+      effort: "medium",
+    });
+    featureResults.findingsCreated = true;
+    logger.action("feature.findings.created", { nugget_id: nugget.id, fact_id: fact.id, insight_id: insight.id });
+  } catch (error) {
+    logger.issue({
+      area: "findings",
+      severity: "medium",
+      title: "Could not create atomic findings",
+      detail: error.message,
+    });
+  }
+  try {
+    const brief = await api.post("/api/interfaces/handoff/brief", { project_id: projectId }, { timeoutMs: 180000 });
+    featureResults.reportGenerated = true;
+    logger.action("feature.report.generated", { result: preview(brief) });
+  } catch (error) {
+    logger.action("feature.report.generated", { ok: false, error: error.message });
+  }
+}
+
+function preview(value) {
+  return JSON.parse(JSON.stringify(value, (_key, val) => {
+    if (typeof val === "string" && val.length > 400) return `${val.slice(0, 400)}...`;
+    return val;
+  }));
+}
+
+function writePlanSnapshot(corpusSummary) {
+  logger.writeJson("benchmark-playbook-snapshot.json", {
+    system_prompt: {
+      source_path: systemPromptPath,
+      copied_to_run: "system-prompt.md",
+      version: systemPromptVersion,
+      sha256: systemPromptHash,
+      bytes: Buffer.byteLength(systemPromptContent, "utf8"),
+    },
+    persona: "Maya Rodrigues, senior UX researcher",
+    project: PROJECT_CONTEXT,
+    requested_full_chat_turns: 100,
+    requested_completed_tasks: 50,
+    requested_researcher_client_count: runtimeResearcherCount,
+    requested_compute_donor_count: donorProfiles.filter((profile) => profile.required).length,
+    compute_donor_profiles: donorProfiles.map(summarizeDonorProfile),
+    generated_chat_turn_templates: buildChatTurns({ total: 108 }),
+    generated_task_templates: buildTaskPlan({ total: 60 }),
+    corpus_summary: {
+      document_count: corpusSummary.document_count,
+      total_bytes: corpusSummary.total_bytes,
+    },
+    integration_policy: "Attempt developer-friendly harnesses first; classify credential-free blockers as product findings.",
+  });
+}
+
+async function main() {
+  captureColimaStorageSnapshot("run-start", { recordIssue: true });
+  logger.action("benchmark.start", {
+    mode,
+    apiBase,
+    frontendUrl,
+    maxChatTurns,
+    maxTasks,
+    maxUploads,
+    startSandbox,
+    skipSandbox,
+    startClientSandboxes,
+    externalConnectionStringMode,
+    freshSandbox,
+    benchmarkTeamMode,
+    hasNetworkAccessToken: Boolean(benchmarkNetworkToken),
+    requireComputeDonation,
+    requireLiveChat,
+    forceDonatedChat,
+    researcher_count: runtimeResearcherCount,
+    donor_count_requested: donorProfiles.filter((profile) => profile.required).length,
+    donor_profiles: donorProfiles.map(summarizeDonorProfile),
+    colima_storage_policy: colimaStoragePolicy,
+    colima_storage_budget: colimaStorageBudget,
+    relayLlm: {
+      provider: relayLlmProvider,
+      provider_source: relayLlmProviderSource,
+      host: hostSummary(relayLlmHost),
+      host_source: relayLlmHostSource,
+      host_localhost_translated_for_container: relayLlmHostRaw !== relayLlmHostForContainer,
+      host_openai_path_stripped_for_native_lmstudio: relayLlmHostNormalized,
+      live_base_url_configured: Boolean(liveLlmProfile.baseUrl),
+      live_base_url_source: liveLlmProfile.baseUrlSource,
+      api_key_configured: Boolean(relayLlmApiKey),
+      api_key_source: relayLlmApiKeySource,
+      model_configured: Boolean(relayLlmModel && relayLlmModel !== "default"),
+      model_source: relayLlmModelSource,
+      model_id_redacted: true,
+    },
+    backgroundAgentsDisabled,
+  });
+
+  const corpus = generateCorpus({ outputDir: logger.paths.corpus, logger });
+  logger.writeJson("corpus-manifest.json", corpus);
+  writePlanSnapshot(corpus);
+
+  if (mode === "plan-only") {
+    blockers.push("Plan-only mode did not attempt live services.");
+    const scorecard = scoreRun({
+      mode,
+      metrics: { corpusDocuments: corpus.document_count },
+      integrationMatrix: [],
+      blockers,
+      completedTasks: 0,
+      chatTurns: 0,
+      uploadedDocuments: 0,
+      sandbox,
+      featureResults,
+    });
+    logger.writeJson("scorecard.json", scorecard);
+    logger.appendReport("Plan-only mode generated the benchmark corpus, playbook snapshot, and scoring scaffold without live app interaction.\n\n");
+    logger.appendReport(writeScorecardMarkdown(scorecard));
+    logger.finalize({ scorecard });
+    return;
+  }
+
+  startServerSandboxIfRequested();
+  const api = new IstaraApiClient({
+    apiBase,
+    repoRoot,
+    logger,
+    networkAccessToken: benchmarkNetworkToken,
+    adminUsername: benchmarkAdminUsername,
+    adminPassword: benchmarkAdminPassword,
+  });
+  const health = await waitForHealth(api, startSandbox && !skipSandbox && sandbox.serverStarted ? 240000 : 15000);
+  if (!health.ok) {
+    blockers.push(`Istara API is unreachable at ${apiBase}.`);
+    logger.issue({
+      area: "install",
+      severity: "critical",
+      title: "Istara API unreachable",
+      detail: health.error || `status=${health.status}`,
+    });
+    const scorecard = scoreRun({
+      mode,
+      metrics: { corpusDocuments: corpus.document_count },
+      integrationMatrix: [],
+      blockers,
+      completedTasks: 0,
+      chatTurns: 0,
+      uploadedDocuments: 0,
+      sandbox,
+      featureResults,
+    });
+    logger.writeJson("scorecard.json", scorecard);
+    logger.appendReport("The benchmark could not reach the Istara API, so the run is a documented environment/product blocker.\n\n");
+    logger.appendReport(writeScorecardMarkdown(scorecard));
+    logger.finalize({ scorecard });
+    return;
+  }
+
+  const auth = await api.authenticate();
+  logger.action("auth.result", auth);
+  if (!auth.ok) {
+    blockers.push(`Benchmark could not authenticate: ${auth.reason || auth.method}`);
+    logger.issue({
+      area: "auth",
+      severity: "critical",
+      title: "Benchmark authentication failed",
+      detail: auth.reason || "No token available.",
+    });
+  }
+
+  let project = null;
+  let uploaded = [];
+  let connectionStrings = {};
+  let integrationMatrix = [];
+  let chatTurnCount = 0;
+  let completedTasks = 0;
+  let researcherInviteResult = null;
+
+  if (auth.ok) {
+    project = await createProject(api);
+    await linkProjectFolder(api, project.id, logger.paths.corpus);
+    uploaded = await uploadCorpus(api, project.id, corpus.manifest, maxUploads);
+    if (uploaded.length > 0) featureResults.uploadedAndQueried = true;
+
+    const initialOverrides = loadConnectionStringOverrides();
+    const connectionOverrides = await maybePromptForConnectionOverrides(initialOverrides);
+    const requiredDonorCount = donorProfiles.filter((profile) => profile.required).length;
+    const hasAllExternalOverrides = connectionOverrides.computeDonations.length >= requiredDonorCount
+      && connectionOverrides.userInvites.length >= runtimeResearcherCount;
+    const shouldGenerateConnectionStrings = !hasAllExternalOverrides || boolEnv("ISTARA_BENCHMARK_GENERATE_CONNECTION_STRINGS_WITH_OVERRIDES", false);
+    const generatedConnectionStrings = shouldGenerateConnectionStrings
+      ? await createConnectionStrings(api, {
+          donorProfilesForRun: donorProfiles,
+          researcherCount: runtimeResearcherCount,
+        })
+      : { userInvites: [], computeDonations: [] };
+    connectionStrings = materializeConnectionStrings(generatedConnectionStrings, connectionOverrides);
+
+    const researcherInviteResults = [];
+    for (let index = 0; index < connectionStrings.userInvites.length; index += 1) {
+      const result = startInviteClientSandbox(connectionStrings.userInvites[index]?.connection_string || "", index);
+      if (result) researcherInviteResults.push(result);
+      await grantResearcherProjectAccess(api, project.id, result);
+    }
+    researcherInviteResult = researcherInviteResults[0] || null;
+    logger.writeJson("connection-client-results.json", {
+      attempted: researcherInviteResults.length > 0,
+      expected_count: runtimeResearcherCount,
+      ok_count: researcherInviteResults.filter((result) => result.ok).length,
+      results: researcherInviteResults.map((result) => ({
+        ok: result.ok,
+        username: result.username,
+        email: result.email,
+        user_id: result.parsed?.user_id || result.parsed?.me_id || "",
+        role: result.parsed?.role || result.parsed?.me_role || "",
+      })),
+    });
+
+    const activeDonorProfiles = [];
+    for (let index = 0; index < donorProfiles.filter((profile) => profile.required).length; index += 1) {
+      const donor = donorProfiles.filter((profile) => profile.required)[index];
+      preflightRelayLlmFromContainer(donor);
+      const donation = connectionStrings.computeDonations.find((item) => item.donor_id === donor.id) || connectionStrings.computeDonations[index];
+      if (donation?.connection_string && donor.enabled) activeDonorProfiles.push(donor);
+      startRelayClientSandbox(donation?.connection_string || "", donor, index);
+    }
+    await verifyComputeDonation(api, project.id, { activeDonorProfiles });
+
+    const uiResult = await runUiJourney({
+      frontendUrl,
+      api,
+      projectId: project.id,
+      logger,
+      chatTurns: buildChatTurns({ total: 5 }),
+      actor: "admin",
+      credentials: {
+        username: benchmarkAdminUsername,
+        password: benchmarkAdminPassword,
+      },
+    });
+    featureResults.uiVisited = uiResult.visited;
+    featureResults.uiOnboarding = uiResult.onboarding;
+
+    if (researcherInviteResult?.ok) {
+      const researcherApi = new IstaraApiClient({
+        apiBase,
+        repoRoot,
+        logger,
+        networkAccessToken: benchmarkNetworkToken,
+        adminUsername: researcherInviteResult.username,
+        adminPassword: researcherInviteResult.password,
+      });
+      const researcherAuth = await researcherApi.authenticate();
+      logger.action("researcher.auth.result", {
+        ok: researcherAuth.ok,
+        method: researcherAuth.method,
+        user_id: researcherAuth.user_id,
+      });
+      if (researcherAuth.ok) {
+        const researcherUiResult = await runUiJourney({
+          frontendUrl,
+          api: researcherApi,
+          projectId: project.id,
+          logger,
+          chatTurns: buildChatTurns({ total: 3 }),
+          actor: "researcher",
+          credentials: {
+            username: researcherInviteResult.username,
+            password: researcherInviteResult.password,
+          },
+        });
+        logger.action("researcher.ui.result", researcherUiResult);
+        featureResults.researcherUi = researcherUiResult.visited && ["chat", "shell", "no_project"].includes(researcherUiResult.finalState);
+      }
+    }
+
+    await exerciseFindingsReports(api, project.id);
+    await exerciseLoopsAutoresearch(api, project.id);
+    integrationMatrix = await runIntegrationMatrix({ api, projectId: project.id, repoRoot, logger });
+    featureResults.interfaces = integrationMatrix.some((item) => ["Google Stitch", "Figma"].includes(item.integration) && item.classification === "developer-harness-tested");
+
+    const turns = buildChatTurns({ total: Math.max(maxChatTurns, 0) }).slice(0, maxChatTurns);
+    if (turns.length > 0) {
+      chatTurnCount = await runChatBenchmark(api, project.id, turns);
+      featureResults.urlFetch = chatTurnCount >= 10 || turns.some((turn) => /URL|fetch|web/i.test(turn.content));
+    }
+
+    completedTasks = await createReviewAndApproveTasks(api, project.id, buildTaskPlan({ total: maxTasks }), uploaded);
+  }
+
+  if (mode === "full" && chatTurnCount < 100) blockers.push(`Full run completed only ${chatTurnCount}/100 required chat turns.`);
+  if (mode === "full" && completedTasks < 50) blockers.push(`Full run completed only ${completedTasks}/50 required reviewed tasks.`);
+
+  captureColimaStorageSnapshot("before-scorecard", { recordIssue: true });
+  const scorecard = scoreRun({
+    mode,
+    metrics: { ...logger.metrics, corpusDocuments: corpus.document_count },
+    integrationMatrix,
+    blockers,
+    completedTasks,
+    chatTurns: chatTurnCount,
+    uploadedDocuments: uploaded.length,
+    sandbox,
+    featureResults,
+  });
+  logger.writeJson("scorecard.json", scorecard);
+  const historyRecord = {
+    run_id: runId,
+    mode,
+    date: new Date().toISOString(),
+    benchmark_id: benchmarkRegistry.benchmark_id,
+    benchmark_registry_version: benchmarkRegistry.version,
+    score: scorecard.total,
+    chat_turns: chatTurnCount,
+    completed_tasks: completedTasks,
+    uploaded_documents: uploaded.length,
+    blocker_count: blockers.length,
+    compute_donation_verified: Boolean(featureResults.computeDonation),
+    multi_donor_compute_verified: Boolean(featureResults.multiDonorCompute),
+    compute_donor_count_requested: donorProfiles.filter((profile) => profile.required).length,
+    compute_donor_count_started: sandbox.relayStartedCount,
+    researcher_client_count_requested: runtimeResearcherCount,
+    researcher_client_count_started: sandbox.researcherStartedCount,
+    live_chat_verified: Boolean(featureResults.liveChat),
+    integration_classifications: scorecard.integration_summary,
+    companion_suites: benchmarkRegistry.companion_suites.map((suite) => suite.path),
+    industry_alignment: benchmarkRegistry.industry_alignment.map((item) => item.reference),
+    live_model_profile: benchmarkRegistry.live_model_profile || { model: PRIMARY_TEST_MODEL },
+    agentic_eval_focus: benchmarkRegistry.agentic_eval_focus?.map((item) => item.area) || [],
+    colima_storage: summarizeColimaStorage(latestColimaStorageSnapshot),
+  };
+  logger.writeJson("history-record.json", historyRecord);
+  logger.rootLine("history.jsonl", historyRecord);
+  logger.writeRootJson("latest-run.json", {
+    ...historyRecord,
+    run_dir: logger.runDir,
+    run_summary: join(logger.runDir, "run-summary.json"),
+    scorecard: join(logger.runDir, "scorecard.json"),
+    report: join(logger.runDir, "report.md"),
+  });
+
+  logger.appendReport("## Run Summary\n\n");
+  logger.appendReport(`Corpus documents generated: ${corpus.document_count}\n\n`);
+  logger.appendReport(`Documents uploaded: ${uploaded.length}\n\n`);
+  logger.appendReport(`Chat turns completed: ${chatTurnCount}\n\n`);
+  logger.appendReport(`Human-approved completed tasks: ${completedTasks}\n\n`);
+  logger.appendReport(`Compute donation verified: ${featureResults.computeDonation ? "yes" : "no"}\n\n`);
+  logger.appendReport(`Compute donor containers: ${sandbox.relayStartedCount}/${donorProfiles.filter((profile) => profile.required).length} started\n\n`);
+  logger.appendReport(`Researcher client containers: ${sandbox.researcherStartedCount}/${runtimeResearcherCount} redeemed\n\n`);
+  logger.appendReport(`Multi-donor compute verified: ${featureResults.multiDonorCompute ? "yes" : "no"}\n\n`);
+  logger.appendReport(`Live model chat verified: ${featureResults.liveChat ? "yes" : "no"}\n\n`);
+  const colimaStorage = summarizeColimaStorage(latestColimaStorageSnapshot);
+  if (colimaStorage) {
+    logger.appendReport(`Colima storage: ${colimaStorage.actual_gb} GB actual, ${colimaStorage.apparent_gb} GB apparent\n\n`);
+  }
+  logger.appendReport(writeScorecardMarkdown(scorecard));
+  logger.appendReport("\n## Actionable Product Improvements\n\n");
+  for (const issue of logger.issues.slice(0, 20)) {
+    logger.appendReport(`- [${issue.severity}] ${issue.area}: ${issue.title}. ${issue.detail}\n`);
+  }
+  cleanupRelayClientSandboxes();
+  logger.finalize({ scorecard, project_id: project?.id || "", uploaded_documents: uploaded.length });
+}
+
+main().catch((error) => {
+  logger.issue({
+    area: "benchmark",
+    severity: "critical",
+    title: "Benchmark crashed",
+    detail: error.stack || error.message,
+  });
+  const scorecard = scoreRun({
+    mode,
+    metrics: logger.metrics,
+    integrationMatrix: [],
+    blockers: [...blockers, error.message],
+    completedTasks: 0,
+    chatTurns: 0,
+    uploadedDocuments: 0,
+    sandbox,
+    featureResults,
+  });
+  logger.writeJson("scorecard.json", scorecard);
+  logger.appendReport("\nBenchmark crashed before completing. See `issues.jsonl` and `action-log.jsonl`.\n\n");
+  logger.appendReport(writeScorecardMarkdown(scorecard));
+  cleanupRelayClientSandboxes();
+  logger.finalize({ scorecard });
+  process.exitCode = 1;
+});

--- a/tests/real_user_benchmark/system-prompt.md
+++ b/tests/real_user_benchmark/system-prompt.md
@@ -1,0 +1,135 @@
+# Istara Real-User Benchmark System Prompt
+
+Version: 2026-05-09.4
+
+You are the Istara Real-User Benchmark Conductor.
+
+Your job is to create, run, debug, and preserve a durable long-form benchmark that tests Istara as a realistic UX researcher would use it. You must behave like a careful senior researcher and systems tester, not a shallow happy-path script.
+
+Core principle:
+Do not treat a failure as an Istara product bug until you have proven it is not caused by your own misunderstanding of Istara's architecture, auth mode, onboarding state, container path mapping, UI render timing, test data, or harness logic.
+
+## Non-Negotiable Rules
+
+- Follow the repo `AGENTS.md` and Compass Forge workflow.
+- Use `rtk` for shell commands.
+- Run `compass-forge status` and `compass-forge agent-brief` before implementation.
+- Create or use a durable Compass Forge spec/work order for standard or larger changes.
+- Run Compass Forge gates before and after meaningful changes.
+- Attach command, gate, review, and run evidence to Compass Forge tasks.
+- Do not touch, delete, move, prune, or clean `LLMs/` or `Model_Finetuning/`.
+- Use the default one bounded configured LLM target/model profile for normal comparison runs.
+- When explicitly running multi-donor compute benchmarks, use only the bounded per-donor profiles requested by the run configuration. Each additional model must already be provisioned; never download or silently load a missing secondary heavy model.
+- For comparison runs, use the shared live-test donated compute profile by default: `google/gemma-4-e4b` from Istara's gitignored/keychain LM Studio/OpenAI-compatible configuration.
+- Do not download secondary heavy models during this benchmark. Qwen3.5-4B is allowed only as an endpoint-gated donor profile once the user supplies an already running/provisioned compatible endpoint.
+- Prefer completing the simulation end to end; when blocked, diagnose, fix, retry, and preserve evidence.
+- Keep Colima/Docker storage bounded. Autostart Colima with `--root-disk 10 --disk 10` unless the user deliberately raises the budget. Record actual and apparent Colima disk snapshots and treat missing storage guardrails as benchmark findings.
+
+## Architecture-Aware Failure Protocol
+
+For every failed action:
+
+1. Pause and classify the current Istara state.
+2. Inspect the relevant architecture: frontend state, backend route, auth/security mode, database/session behavior, Docker/network path, or integration contract.
+3. Decide whether the failure is caused by harness assumptions, missing setup, UI not rendered, auth/onboarding state, container visibility, or a real product gap.
+4. If it is harness/setup misunderstanding, fix the harness or setup and retry.
+5. If a dependent next step is blocked, use Compass Forge and, when available/authorized, spawn a focused helper agent to inspect or fix the blocker.
+6. Only log a product issue after retrying with corrected understanding and preserving evidence.
+
+## Playwright/UI Protocol
+
+- Use real browser automation.
+- Never navigate blindly.
+- Wait for the UI to finish rendering and classify state before every navigation or chat action.
+- Recognize at least: blank, connecting, server-unreachable, login, onboarding/tour, no-project, shell, chat, error.
+- Complete or align onboarding/tour state only after observing the real UI flow and recording why.
+- Prefer accessible selectors: roles, labels, tab names, button names, aria-labels.
+- If a UI element is not found, capture screenshot, DOM/body preview, console errors, network failures, current URL, auth state, active project, and relevant localStorage before deciding.
+- The Chat menu is a real Istara surface. Do not conclude "chat input missing" until you verify whether the app is actually on Chat, project is selected, tour is not redirecting, and runtime config/CSP/auth are correct.
+
+## Required Benchmark
+
+Create and run a repeatable benchmark under the repo, normally `tests/real_user_benchmark/`, with scripts, docs, synthetic data generation, Playwright automation, logging, screenshots/traces, scoring, and final reports.
+
+This benchmark is a longitudinal real-user layer. Do not re-run or re-implement the classical deterministic studies already covered by `tests/simulation`, `tests/evals`, `tests/benchmarks`, or `scripts/security_benchmark.py`. Use those suites as baseline evidence and coverage references. This benchmark should add realistic cross-feature user behavior, compute donation, integration ergonomics, human task review, longitudinal usefulness, and product-risk evidence.
+
+The simulation must:
+
+- Start a fresh sandbox/container Istara server.
+- Generate an Istara connection string.
+- Start/connect a separate sandbox/container client using that connection string.
+- Complete onboarding through the real UI.
+- Invent a realistic UX researcher persona and project context.
+- Generate a large messy prior UX research corpus: interviews, usability tests, survey CSVs, diary studies, field notes, analytics, briefs/presentations, competitor notes, support tickets, design notes, malformed files, multilingual examples, and edge cases.
+- Add context, guardrails, folders, uploads, and new docs through UI where possible.
+- Conduct at least 100 natural Chat turns as a real researcher: clarify, steer, challenge, correct, upload, ask for evidence, request reports, ask follow-ups.
+- Treat chat as useful only when Istara returns non-empty live model output through the configured donated compute path or a deliberately documented equivalent. Empty mocked output is not a valid real-user benchmark pass.
+- Create and exercise at least 50 human-reviewed completed tasks.
+- For tasks in Review, read outputs, judge quality, approve good work, and send weak/vague/unsupported work back with concrete revision instructions.
+- Exercise uploads, context, search/RAG, task creation/correction, loops, Autoresearch, surveys, AURA-style deployments, Telegram-style deployment, URL/web fetching, reports, findings/atomic research, interfaces/design generation, compute/connection-string behavior, and other discovered Istara features.
+- Exercise agentic surfaces as real user needs reveal them: tool calling, skill calling, RAG/source retrieval, context management, memento/project memory, ReasoningBank, Hyperagent/governed improvement, compute health, ensemble/MoA readiness, and observability of those behaviors.
+
+## Compute Donation And Live Model Protocol
+
+- Use the correct live-test model id: `google/gemma-4-e4b`.
+- Load the target host/token/model from Istara's existing testing configuration, gitignored env, or Keychain. Never log private endpoint values, tokens, or endpoint fingerprints.
+- If the configured host is localhost from inside a container, reason through container networking and use the correct host bridge path such as `host.docker.internal`.
+- Generate an admin/server sandbox and a separate client/researcher sandbox. Verify both users can authenticate and act through the UI.
+- Verify compute donation with evidence: relay/client registration, `/api/compute/stats`, forced topology or backend route logs, and an actual chat response.
+- Treat server sandboxing and client/donor sandboxing as separate concerns. The benchmark may target an Istara orchestrator already running outside Docker while still starting disposable researcher and donor containers.
+- For multi-donor runs, ask or read how many compute donor containers are required, assign one connection string per donor, preflight each donor's own LM Studio/OpenAI-compatible endpoint, and wait for the requested relay-node count in `/api/compute/stats`.
+- The default first donor is Gemma (`google/gemma-4-e4b`). A second Qwen donor (`Qwen3.5-4B`) must be explicitly provisioned through a separate endpoint/profile; missing Qwen provisioning is a benchmark blocker, not something to fake or auto-download.
+- Do not claim ensemble/MoA health unless multiple required donor nodes are registered and chat/compute evidence shows the orchestrator can use donated compute.
+- If donation fails, iterate until the technical reason is known: wrong model id, model not loaded, token/auth issue, container networking, server direct-provider fallback, route scoring, circuit breaker, or missing product support.
+- Do not proceed to score chat/task/research quality as successful until live chat returns real output.
+
+## Integration Protocol
+
+No real third-party credentials are available by default. Still attempt every integration path.
+
+For Google Stitch, Figma, Google Forms, SurveyMonkey, Typeform, Telegram, messaging channels, survey sync, MCP, and related integrations:
+
+- First inspect code/API/docs for mock endpoints, sandbox modes, local host overrides, webhook simulators, fixture syncs, fake providers, or test doubles.
+- Use developer-friendly paths when available.
+- If none exist, test setup UI, validation, graceful error states, docs clarity, and blocker behavior.
+- Classify each integration as one of: `live-tested`, `developer-harness-tested`, `setup-error-path-tested`, `blocked-no-test-harness`, `not-implemented`.
+- Treat missing credential-free developer test paths as product findings.
+
+## Telegram/AURA
+
+- Without a real bot token, test channel creation, fake credential behavior, activation failure, deployment linking, and graceful errors.
+- If a local deployment/conversation simulator exists, use it to simulate participant conversations, adaptive follow-ups, response capture, findings, analytics, and reports.
+- If no simulator exists, prove that with route/code evidence and log it as a product finding.
+
+## Evidence Requirements
+
+Create a timestamped result folder for every run. Capture:
+
+- full action log JSONL
+- all chat turns JSONL
+- task creation/review/revision/approval log
+- integration attempts and classifications
+- screenshots and Playwright traces
+- server/client install logs
+- API/network failures
+- corpus manifest
+- uploaded document manifest
+- report/interface artifacts
+- issues/product risks
+- scoring report
+- comparison-ready history data
+- registry/alignment data that links the run to existing Istara testing/eval suites and industry-style benchmark evidence practices
+- per-donor compute preflight, relay registration, connection-string materialization, and multi-donor/ensemble health evidence when multi-donor mode is enabled
+
+## Final Deliverables
+
+- Reusable benchmark implementation and documentation.
+- README with rerun instructions, optional live credential paths, and credential-free fallbacks.
+- Benchmark playbook with persona, project narrative, corpus, feature matrix, and rubric.
+- Completed full run with at least 100 chat turns and 50 human-approved tasks, unless blocked by a proven product issue.
+- Scorecard out of 100 covering install, onboarding, chat, grounding, task execution, human review, reports, integrations, Autoresearch/loops, URL fetching, interfaces, stability, performance, and researcher usefulness.
+- Actionable product improvements, especially missing developer test harnesses.
+
+## Standard Of Success
+
+The benchmark should be reusable months later to compare Istara builds. It should feel like a real UX researcher used the system, got confused sometimes, corrected course, reviewed work critically, and left behind enough evidence for product and engineering teams to understand what happened.


### PR DESCRIPTION
## Summary

Adds a durable real-user UX research benchmark harness under `tests/real_user_benchmark/`.

The harness covers reusable benchmark documentation, synthetic research corpus generation, Playwright UI journeys, API-backed feature exercise, task review logging, integration classification, scoring, and run history. It also adds the multi-donor compute mode discussed for one Istara orchestrator receiving compute from multiple disposable donor containers.

## Why

Istara needs a repeatable long-form benchmark that behaves like a real UX researcher instead of a narrow happy-path script. The new harness preserves evidence across runs and makes future regressions/comparisons easier to inspect.

## Notable Details

- Adds external-orchestrator mode where Istara can run outside Docker while benchmark donor/researcher containers connect through provided connection strings.
- Separates server sandboxing from client/donor sandboxing.
- Defaults donor 1 to the configured `google/gemma-4-e4b` profile.
- Makes the Qwen `Qwen3.5-4B` donor endpoint-gated: no model download or fake success when not provisioned.
- Logs per-donor preflight, compute registration, route evidence, and comparison-ready history data while keeping endpoints/tokens redacted.
- Includes a benchmark-local `.gitignore` for `.results/` and `node_modules/`.

## Validation

- `npm --prefix tests/real_user_benchmark run check`
- `jq empty tests/real_user_benchmark/benchmark-registry.json`
- `npm --prefix tests/real_user_benchmark run plan -- --run-id multi-donor-final-plan`
- `ISTARA_BENCHMARK_DONOR_COUNT=2 ISTARA_BENCHMARK_DONOR_2_LLM_HOST=http://localhost:2234 ISTARA_BENCHMARK_DONOR_2_LLM_MODEL=Qwen3.5-4B npm --prefix tests/real_user_benchmark run plan -- --run-id multi-donor-two-lmstudio-plan`
- `python scripts/security_benchmark.py --fail-on-threshold` => pass, 100%
- `compass-forge gate before --task CF-560` => pass
- `compass-forge gate after --task CF-560` => pass
